### PR TITLE
Fix README.txt to match actually required procedure

### DIFF
--- a/test/README.txt
+++ b/test/README.txt
@@ -2,7 +2,8 @@ Test ippserver Configuration
 -----------------------------------
 
 To start the ippserver instance:
-  Simply run "./start-server.sh" from the folder where this README.txt file resides.
+  Simply run "./test/start-server.sh" from the folder one level higher than where
+  this README.txt file resides.
   The "start-server.sh" script calls ippserver with a set of arguments to use the
   configuration in this directory.
 


### PR DESCRIPTION
Current README.txt instructs to run *'./start-server.sh from the folder where this README.txt file resides'*.  This is wrong and does not work. Users should actually run *`./test/start-server.sh`* from one directory level higher.
  