### PR TITLE
Add AppVeyor build for Windows, use zlib NuGet package

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,34 @@
+version: "{build}"
+image: Visual Studio 2017
+
+# Uncomment to debug via RDP
+# init:
+#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+install:
+  # Install a self-signed certificate
+  - ps: |
+      $selfsigncert = New-SelfSignedCertificate `
+      -Subject 'CN=IEEE INDUSTRY STANDARDS AND TECHNOLOGY ORGANIZATION' `
+      -KeyAlgorithm RSA -KeyLength 2048 -Type CodeSigningCert `
+      -CertStoreLocation Cert:\CurrentUser\My
+
+  # Install zlib dependency
+  - ps: nuget restore vcnet\ippsample.sln
+
+build_script:
+  - ps: msbuild.exe vcnet\ippsample.sln /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v140
+
+test_script:
+  - .\vcnet\x64\Release\ippfind.exe --help
+  - .\vcnet\x64\Release\ipptool.exe --version
+  - .\vcnet\x64\Release\ippserver.exe --help
+
+artifacts:
+  - path: '**\*.exe'
+    name: Binaries
+  - path: '**\*.dll'
+    name: Libs


### PR DESCRIPTION
This is the minimal change to introduce a first Windows build with [AppVeyor CI](https://www.appveyor.com).

- Added `.appveyor.yml`
  - Create a self-signed certificate to make the `signtool.exe` build steps happy

- Start using NuGet to manage packages for the Visual Studio Solution

  - Added `vcnet/packages.config` which contains the zlib dependency with name and version
  - You can restore the dependencies in the command line: `nuget restore vcnet\ippsample.sln`
  - You can restore the dependencies in Visual Studio 

<img width="643" alt="manage-packages-for-solution" src="https://user-images.githubusercontent.com/207759/39665843-73ae464a-509a-11e8-9040-e5e619f64e50.png">

    - Right click on the Solution
      - Manage NuGet Packages for Solution...
      - Restore NuGet Packages

- Added the AppVeyor Build Status Badge to the README.md
  - This should be updated once you have activated AppVeyor builds for istopwg/ippsample repo.

At the moment you can see my forked builds. The [build #25](https://ci.appveyor.com/project/StefanScherer/ippsample/build/25) shows the current status. The build errors at 

```
  ..\cups\http-support.c(16): fatal error C1083: Cannot open include file: 'dns_sd.h': No such file or directory [C:\projects\ippsample\vcnet\libcups2.vcxproj]
```

With this PR I don't want to change too many files, just to get started with AppVeyor.

A next PR will have some code changes to improve the compilation of libcups2 on Windows.

A general question is how we could proceed with the Bonjour SDK for the `HAVE_DNSSD` compile switch?

