### PR TITLE
Use dockerized Ubuntu 18.04 build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,8 @@ matrix:
   include:
     # Linux-specific build stuff
     - os: linux
-      before_install:
-        - sudo apt-get -qq update
-        # Note: Because Travis CI does not yet support Ubuntu Xenial 18.04, we
-        # cannot do build tests with MuPDF or other dependencies since the
-        # projects just aren't there... :/
-        # - sudo apt-get install -y avahi-daemon avahi-utils cura-engine libavahi-client-dev libfreetype6-dev libgnutls28-dev libharfbuzz-dev libjbig2dec0-dev libjpeg-dev libmupdf-dev libnss-mdns libopenjp2-7-dev libpng-dev zlib1g-dev
-        - sudo apt-get install -y avahi-daemon avahi-utils libavahi-client-dev libgnutls28-dev libjpeg-dev libnss-mdns libpng-dev zlib1g-dev
+      script:
+        - docker build -t ippsample .
 
     # macOS-specific build stuff
     - os: osx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y build-essential autoconf avahi-daemon avahi-utils cura-engine libavahi-client-dev libfreetype6-dev libgnutls28-dev libharfbuzz-dev libjbig2dec0-dev libjpeg-dev libmupdf-dev libnss-mdns libopenjp2-7-dev libpng-dev zlib1g-dev net-tools iputils-ping vim avahi-daemon tcpdump man curl
+RUN apt-get -qq update && apt-get install -y build-essential autoconf avahi-daemon avahi-utils cura-engine libavahi-client-dev libfreetype6-dev libgnutls28-dev libharfbuzz-dev libjbig2dec0-dev libjpeg-dev libmupdf-dev libnss-mdns libopenjp2-7-dev libpng-dev zlib1g-dev net-tools iputils-ping vim avahi-daemon tcpdump man curl
 RUN /bin/echo 'colorscheme blue' > ~/.vimrc
 RUN /bin/echo "LS_COLORS=\$LS_COLORS:'di=0;31:' ; export LS_COLORS" >> /root/.bashrc
 # Make changes necessary to run bonjour
@@ -23,4 +23,4 @@ RUN cd /root/ippsample; ./configure
 
 # Copy rest of the sources to use build cache as far as possible
 COPY . /root/ippsample/
-RUN cd /root/ippsample; make; make install
+RUN cd /root/ippsample; make; make test; make install


### PR DESCRIPTION
This change uses Travis with a docker build to run the build and test in Ubuntu 18.04.

I've changed the `.travis.yml` to use the `Dockerfile` in the repo with all build steps.
I've updated the `Dockerfile` a little bit to run the tests as well.

The `Dockerfile` has `FROM ubuntu:latest` in the first line which means it pulls the latest ubuntu image from Docker Hub https://hub.docker.com/_/ubuntu/ .
The tag `latest` is identical to `18.04` so we can easily switch to the current Ubuntu version without waiting for Travis to update the build machines.

A sample Travis build is here https://travis-ci.org/StefanScherer/ippsample/jobs/408820484
