### PR TITLE
GSOC 2018: Enhancments for Ipptool

### DIFF
--- a/examples/ipp-1.1.test
+++ b/examples/ipp-1.1.test
@@ -233,48 +233,82 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	EXPECT operations-supported WITH-VALUE 0x000b # Get-Printer-Attributes
 	EXPECT operations-supported WITH-VALUE 0x000c DEFINE-MATCH OPTIONAL_HOLD_JOB # Hold-Job
 	EXPECT operations-supported WITH-VALUE 0x000d DEFINE-MATCH OPTIONAL_RELEASE_JOB # Release-Job
-	EXPECT operations-supported WITH-VALUE 0x000e DEFINE-MATCH OPTIONAL_RESTART_JOB # Restart-Job
+	EXPECT operations-supported WITH-VALUE 0x000e DEFINE-MATCH OPTIONAL_RESTART_JOB # Restart-Job                
 	EXPECT operations-supported WITH-VALUE 0x0010 DEFINE-MATCH OPTIONAL_PAUSE_PRINTER # Pause-Printer
 	EXPECT operations-supported WITH-VALUE 0x0011 DEFINE-MATCH OPTIONAL_RESUME_PRINTER # Resume-Printer
-	EXPECT operations-supported WITH-VALUE 0x0012 DEFINE-MATCH OPTIONAL_PURGE_JOBS # Purge-Jobs
+	EXPECT operations-supported WITH-VALUE 0x0012 DEFINE-MATCH OPTIONAL_PURGE_JOBS # Purge-Jobs                  
+
+	#checks for operations expected to exist in pairs
+	EXPECT operations-supported WITH-VALUE 0x000c IF-DEFINED OPTIONAL_RELEASE_JOB                        
+	EXPECT operations-supported WITH-VALUE 0x000d IF-DEFINED OPTIONAL_HOLD_JOB                           
+	EXPECT operations-supported WITH-VALUE 0x0011 IF-DEFINED OPTIONAL_PAUSE_PRINTER                      
+	EXPECT operations-supported WITH-VALUE 0x0010 IF-DEFINED OPTIONAL_RESUME_PRINTER                     
 
 	# Job template attributes
+	EXPECT ?job-priority-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0,<101
+	EXPECT ?job-priority-supported OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0,<101
+	EXPECT ?job-hold-until-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT ?job-hold-until-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE no-hold
+	EXPECT job-hold-until-default IF-DEFINED OPTIONAL_HOLD_JOB            
+	EXPECT job-hold-until-supported IF-DEFINED OPTIONAL_HOLD_JOB           
+	EXPECT ?job-sheets-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag
+	EXPECT ?job-sheets-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE none
+	EXPECT ?multiple-document-handling-default OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
+	EXPECT ?multiple-document-handling-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
 	EXPECT ?copies-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
 	EXPECT ?copies-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag
 	EXPECT ?finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag
 	EXPECT ?finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3
-	EXPECT ?job-hold-until-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1
-	EXPECT ?job-hold-until-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE no-hold
-	EXPECT job-hold-until-default IF-DEFINED OPTIONAL_HOLD_JOB
-	EXPECT job-hold-until-supported IF-DEFINED OPTIONAL_HOLD_JOB
-	EXPECT ?job-priority-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0,<101
-	EXPECT ?job-priority-supported OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0,<101
-	EXPECT ?job-sheets-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag
-	EXPECT ?job-sheets-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE none
-	EXPECT ?media-default OF-TYPE no-value|keyword|name IN-GROUP printer-attributes-tag COUNT 1
-	EXPECT ?media-ready OF-TYPE keyword|name IN-GROUP printer-attributes-tag
-	EXPECT ?media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag
-	EXPECT ?multiple-document-handling-default OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
-	EXPECT ?multiple-document-handling-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
+	EXPECT ?sides-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
+	EXPECT ?sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
 	EXPECT ?number-up-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
 	EXPECT ?number-up-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >0
 	EXPECT ?number-up-supported WITH-VALUE 1
 	EXPECT ?orientation-requested-default OF-TYPE no-value|enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5,6
 	EXPECT ?orientation-requested-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5,6
-	EXPECT ?pages-ranges-supported OF-TYPE boolean IN-GROUP printer-attributes-tag
-	EXPECT ?print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
-	EXPECT ?print-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5
+	EXPECT ?media-default OF-TYPE no-value|keyword|name IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT ?media-ready OF-TYPE keyword|name IN-GROUP printer-attributes-tag
+	EXPECT ?media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag
 	EXPECT ?printer-resolution-default OF-TYPE resolution IN-GROUP printer-attributes-tag COUNT 1
 	EXPECT ?printer-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag
-	EXPECT ?sides-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
-	EXPECT ?sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
-
+	EXPECT ?print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
+	EXPECT ?print-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5
+	EXPECT ?pages-ranges-supported OF-TYPE boolean IN-GROUP printer-attributes-tag
+	
+	
 	# Job template attributes for specific tests...
-	EXPECT copies-supported WITH-VALUE >1 DEFINE-MATCH OPTIONAL_COPIES
-	EXPECT document-format-supported WITH-VALUE "application/pdf" DEFINE-MATCH OPTIONAL_PDF
-	EXPECT document-format-supported WITH-VALUE "application/postscript" DEFINE-MATCH OPTIONAL_POSTSCRIPT
-	EXPECT document-format-supported WITH-VALUE "image/jpeg" DEFINE-MATCH OPTIONAL_JPEG
+	EXPECT job-priority-supported WITH-VALUE >1 DEFINE-MATCH OPTIONAL_PRIORITY
 	EXPECT job-sheets-supported WITH-VALUE "standard" DEFINE-MATCH OPTIONAL_STANDARD_SHEET
+	EXPECT multiple-document-handling-supported WITH-VALUE "single-document" DEFINE-MATCH OPTIONAL_SD_MULTIPLE_DOCUMENT_HANDLING #SD stands for single document
+	EXPECT multiple-document-handling-supported WITH-VALUE "separate-documents-uncollated-copies" DEFINE-MATCH OPTIONAL_SDUC_MULTIPLE_DOCUMENT_HANDLING #SDUC stands for seperate document uncollated copies.
+	#EXPECT multiple-document-handling-supported WITH-VALUE "separate-documents-collated-copies" DEFINE-MATCH OPTIONAL_SDCC_MULTIPLE_DOCUMENT_HANDLING #SDCC stands for seperate document collated copies.
+	EXPECT multiple-document-handling-supported WITH-VALUE "single-document-new-sheet" DEFINE-MATCH OPTIONAL_SDNS_MULTIPLE_DOCUMENT_HANDLING #SDNS stands for single document new sheet.
+	EXPECT copies-supported WITH-VALUE >1 DEFINE-MATCH OPTIONAL_COPIES
+	EXPECT finishings-supported WITH-VALUE 4 DEFINE-MATCH OPTIONAL_SATPLE
+	EXPECT finishings-supported WITH-VALUE 5 DEFINE-MATCH OPTIONAL_PUNCH
+	EXPECT finishings-supported WITH-VALUE 6 DEFINE-MATCH OPTIONAL_COVER
+	EXPECT finishings-supported WITH-VALUE 7 DEFINE-MATCH OPTIONAL_BIND
+	EXPECT finishings-supported WITH-VALUE 8 DEFINE-MATCH OPTIONAL_SADDLESTITCH
+	EXPECT finishings-supported WITH-VALUE 9 DEFINE-MATCH OPTIONAL_EDGESTITCH
+	EXPECT finishings-supported WITH-VALUE 20 DEFINE-MATCH OPTIONAL_STAPLETOPLEFT
+	EXPECT finishings-supported WITH-VALUE 21 DEFINE-MATCH OPTIONAL_STAPLEBOTTOMLEFT
+	EXPECT finishings-supported WITH-VALUE 22 DEFINE-MATCH OPTIONAL_STAPLETOPRIGHT
+	EXPECT finishings-supported WITH-VALUE 23 DEFINE-MATCH OPTIONAL_STAPLEBOTTOMRIGHT
+	EXPECT finishings-supported WITH-VALUE 24 DEFINE-MATCH OPTIONAL_EDGESTITCHLEFT
+	EXPECT finishings_supported WITH-VALUE 25 DEFINE-MATCH OPTIONAL_EDGESTITCHTOP
+	EXPECT finishings_supported WITH-VALUE 26 DEFINE-MATCH OPTIONAL_EDGESTITCHRIGHT
+	EXPECT finishings_supported WITH-VALUE 27 DEFINE-MATCH OPTIONAL_EDGESTITCHBOTTOM
+	EXPECT finishings_supported WITH-VALUE 28 DEFINE-MATCH OPTIONAL_STAPLEDUALLEFT
+	EXPECT finishings_supported WITH-VALUE 29 DEFINE-MATCH OPTIONAL_STAPLEDUALTOP
+	EXPECT finishings_supported WITH-VALUE 30 DEFINE-MATCH OPTIONAL_STAPLEDUALRIGHT
+	EXPECT finishings_supported WITH-VALUE 31 DEFINE-MATCH OPTIONAL_STAPLEDUALBOTTOM
+	EXPECT sides-supported WITH-VALUE "two-sided-long-edge" DEFINE-MATCH OPTIONAL_DUPLEX_LONGEDGE
+	EXPECT sides-supported WITH-VALUE "two-sided-short-edge" DEFINE-MATCH OPTIONAL_DUPLEX_SHORTEDGE
+	EXPECT number-up-supported WITH-VALUE 2 DEFINE-MATCH OPTIONAL_2UP
+	EXPECT orientation-requested-supported WITH-VALUE 3 DEFINE-MATCH OPTIONAL_PORTRAIT
+	EXPECT orientation-requested-supported WITH-VALUE 4 DEFINE-MATCH OPTIONAL_LANDSCAPE
+	EXPECT orientation-requested-supported WITH-VALUE 5 DEFINE-MATCH OPTIONAL_REVERSELANDSCAPE
+	EXPECT orientation-requested-supported WITH-VALUE 6 DEFINE-MATCH OPTIONAL_REVERSEPORTRAIT
 	EXPECT media-supported WITH-VALUE "a4" DEFINE-VALUE OPTIONAL_A4_MEDIA
 	EXPECT media-supported WITH-VALUE "iso-a4" DEFINE-VALUE OPTIONAL_A4_MEDIA
 	EXPECT media-supported WITH-VALUE "iso_a4_210x297mm" DEFINE-VALUE OPTIONAL_A4_MEDIA
@@ -283,12 +317,15 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	EXPECT media-supported WITH-VALUE "na_letter_8.5x11in" DEFINE-VALUE OPTIONAL_LETTER_MEDIA
 	EXPECT media-supported WITH-VALUE "index-4x6" DEFINE-VALUE OPTIONAL_4X6_MEDIA
 	EXPECT media-supported WITH-VALUE "na_index-4x6_4x6in" DEFINE-VALUE OPTIONAL_4X6_MEDIA
-	EXPECT number-up-supported WITH-VALUE 2 DEFINE-MATCH OPTIONAL_2UP
-	EXPECT print-quality WITH-VALUE 3 DEFINE-MATCH OPTIONAL_DRAFT_QUALITY
-	EXPECT print-quality WITH-VALUE 4 DEFINE-MATCH OPTIONAL_NORMAL_QUALITY
-	EXPECT print-quality WITH-VALUE 5 DEFINE-MATCH OPTIONAL_BEST_QUALITY
-	EXPECT sides-supported WITH-VALUE "two-sided-long-edge" DEFINE-MATCH OPTIONAL_DUPLEX
+	EXPECT document-format-supported WITH-VALUE "application/pdf" DEFINE-MATCH OPTIONAL_PDF
+	EXPECT document-format-supported WITH-VALUE "application/postscript" DEFINE-MATCH OPTIONAL_POSTSCRIPT
+	EXPECT document-format-supported WITH-VALUE "image/jpeg" DEFINE-MATCH OPTIONAL_JPEG
+	EXPECT print-quality-supported WITH-VALUE 3 DEFINE-MATCH OPTIONAL_DRAFT_QUALITY
+	EXPECT print-quality-supported WITH-VALUE 4 DEFINE-MATCH OPTIONAL_NORMAL_QUALITY
+	EXPECT print-quality-supported WITH-VALUE 5 DEFINE-MATCH OPTIONAL_BEST_QUALITY
+	EXPECT print-resolution-supported WITH-VALUE 600dpi DEFINE-MATCH OPTIONAL_PRINT_RESOLUTION
 
+	
 	# Printer description attributes
 	EXPECT ?color-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
 	EXPECT ?job-impressions-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag COUNT 1
@@ -1233,6 +1270,165 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	STATUS server-error-job-canceled
 }
 
+#test Pause-Printer operation followed by resume printer operation
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_PAUSE_PRINTER
+
+	NAME "RFC 8011 section 4.2.7: Pause-Printer Operation"
+	
+	Operation Pause-Printer
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri                                                             
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+#Resume-Printer operation
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_RESUME_PRINTER
+
+	Name "Resume-Printer"
+
+	Operation Resume-Printer
+
+	Group operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	Status successful-ok
+}
+
+
+# Test Print-Job operation
+{
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE >0 DEFINE-VALUE JOBID_HOLDTEST
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state WITH-VALUE 7,8,9 DEFINE-MATCH PRINT_JOB_COMPLETED
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+
+# Test Hold-Job operation
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_HOLD_JOB
+
+	Name "RFC 8011 section 4.3.5: Hold-Job operation"
+
+	Operation Hold-Job
+
+	Group operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_HOLDTEST
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+#Release-Job Operation
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_HOLD_JOB      
+	SKIP-IF-NOT-DEFINED OPTIONAL_RELEASE_JOB				
+
+	NAME "Release-Job"
+	OPERATION Release-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+#testing Create-Job with job-hold-until attribute
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_CREATE_JOB
+	SKIP-IF-NOT-DEFINED OPTIONAL_SEND_DOCUMENT
+	
+
+	NAME "RFC 8011 section 4.2.4: Create-Job Operation"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword job-hold-until indefinite
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_CREATE_JOB
+	SKIP-IF-NOT-DEFINED OPTIONAL_SEND_DOCUMENT
+	
+
+	NAME "RFC 8011 section 4.3.1: Send-Document Operation"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR boolean last-document true
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
 
 # Test multiple copy output
 {
@@ -1259,8 +1455,8 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	STATUS server-error-job-canceled
 	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
 
-	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
-	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME" 
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag 
 	       WITH-VALUE >0
 	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
 	       WITH-VALUE 3,4,5,6,7,8,9
@@ -1788,7 +1984,6 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	       IN-GROUP job-attributes-tag WITH-VALUE >-1
 }
 
-
 # Print-Job with job-sheets
 {
 	SKIP-IF-DEFINED NOPRINT
@@ -1810,7 +2005,7 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	ATTR mimeMediaType document-format application/pdf
 	GROUP job-attributes-tag
 	ATTR keyword media $OPTIONAL_A4_MEDIA
-	ATTR keyword job-sheets standard
+	ATTR keyword job-sheets "standard"
 	FILE document-a4.pdf
 
 	STATUS successful-ok
@@ -1848,7 +2043,7 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	ATTR mimeMediaType document-format application/pdf
 	GROUP job-attributes-tag
 	ATTR keyword media $OPTIONAL_LETTER_MEDIA
-	ATTR keyword job-sheets standard
+	ATTR keyword job-sheets "standard"
 	FILE document-a4.pdf
 
 	STATUS successful-ok
@@ -1886,7 +2081,7 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	ATTR mimeMediaType document-format application/postscript
 	GROUP job-attributes-tag
 	ATTR keyword media $OPTIONAL_A4_MEDIA
-	ATTR keyword job-sheets standard
+	ATTR keyword job-sheets "standard"
 	FILE document-a4.ps
 
 	STATUS successful-ok
@@ -1924,7 +2119,7 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	ATTR mimeMediaType document-format application/postscript
 	GROUP job-attributes-tag
 	ATTR keyword media $OPTIONAL_LETTER_MEDIA
-	ATTR keyword job-sheets standard
+	ATTR keyword job-sheets "standard"
 	FILE document-a4.ps
 
 	STATUS successful-ok
@@ -1941,7 +2136,6 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 	EXPECT ?number-of-intervening-jobs OF-TYPE integer
 	       IN-GROUP job-attributes-tag WITH-VALUE >-1
 }
-
 
 # Test number-up output
 {
@@ -2324,7 +2518,9 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 }
 
 {
-	SKIP-IF-NOT-DEFINED OPTIONAL_HOLD_JOB
+	SKIP-IF-NOT-DEFINED OPTIONAL_HOLD_JOB      
+	SKIP-IF-NOT-DEFINED OPTIONAL_RELEASE_JOB				
+	
 
 	NAME "Release-Job"
 	OPERATION Release-Job
@@ -2337,4 +2533,1084 @@ DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
 
 	STATUS successful-ok
 	STATUS client-error-not-possible
+}
+
+# Test print-job with explicit print priority
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_PRIORITY
+
+	NAME "Print-Job with explicit priority"
+	
+	OPERATION Print-Job
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR integer job-priority 2
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test print-job with multiple_document_handling
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SD_MULTIPLE_DOCUMENT_HANDLING
+
+	NAME "Print-Job with single-document multiple-document-handling"
+	
+	OPERATION Print-Job
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword multiple-document-handling "single-document"
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SDUC_MULTIPLE_DOCUMENT_HANDLING
+
+	NAME "Print-Job with separate-documents-uncollated-copies multiple-document-handling"
+	
+	OPERATION Print-Job
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword multiple-document-handling "separate-documents-uncollated-copies"
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SDCC_MULTIPLE_DOCUMENT_HANDLING
+
+	NAME "Print-Job with separate-documents-collated-copies multiple-document-handling"
+	
+	OPERATION Print-Job
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword multiple-document-handling "separate-documents-collated-copies"
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SDNS_MULTIPLE_DOCUMENT_HANDLING
+
+	NAME "Print-Job with ssingle-document-new-sheet multiple-document-handling"
+	
+	OPERATION Print-Job
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword multiple-document-handling "single-document-new-sheet"
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# print-job tests with different values of finishings job-template attribute
+{
+	NAME "Print-Job with no finishing"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 3
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLE
+
+	NAME "Print-Job with staple"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 4
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_PUNCH
+
+	NAME "Print-Job with punch"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 5
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_COVER
+
+	NAME "Print-Job with cover"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 6
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_BIND
+
+	NAME "Print-Job with bind"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 7
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SADDLESTITCH
+
+	NAME "Print-Job with saddle-stitch"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 8
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_EDGESTITCH
+
+	NAME "Print-Job with edge-stitch"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 9
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLETOPLEFT
+
+	NAME "Print-Job with staple-top-left"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 20
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLEBOTTOMLEFT
+
+	NAME "Print-Job with staple-bottom-left"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 21
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLETOPRIGHT
+
+	NAME "Print-Job with staple-top-right"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 22
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLEBOTTOMRIGHT
+
+	NAME "Print-Job with staple-bottom-right"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 23
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_EDGESTITCHLEFT
+
+	NAME "Print-Job with edge-stitch-left"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 24
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_EDGESTITCHTOP
+
+	NAME "Print-Job with edge-stitch-top"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 25
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_EDGESTITCHRIGHT
+
+	NAME "Print-Job with edge-stitch-right"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 26
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_EDGESTITCHBOTTOM
+
+	NAME "Print-Job with edge-stitch-bottom"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 27
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLEDUALLEFT
+
+	NAME "Print-Job with staple-dual-left"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 28
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLEDUALTOP
+
+	NAME "Print-Job with staple-dual-top"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 29
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLEDUALRIGHT
+
+	NAME "Print-Job with staple-dual-right"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 30
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STAPLEDUALBOTTOM
+
+	NAME "Print-Job with staple-dual-bottom"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum finishings 31
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#print-job tests with different values for sides job-template-attribute
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_DUPLEX_LONGEDGE
+
+	NAME "Print-Job with two-sided-long-edge side"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR keyword sides "two-sided-long-edge"
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_DUPLEX_SHORTEDGE
+
+	NAME "Print-Job with two-sided-short-edge side"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR keyword sides "two-sided-short-edge"
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+
+#print-job with differnt orientations
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_PORTRAIT
+
+	NAME "Print-Job with portrait orientation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum orientation-requested 3
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_LANDSCAPE
+
+	NAME "Print-Job with landscape orientation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum orientation-requested 4
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_REVERSEPORTRAIT
+
+	NAME "Print-Job with portrait orientation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum orientation-requested 5
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_REVERSEPORTRAIT
+
+	NAME "Print-Job with portrait orientation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR enum orientation-requested 6
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_PRINT_RESOLUTION
+
+	NAME "Print-Job with 600dpi resolution"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	GROUP job-attributes-tag
+	ATTR resolution printer-resolution 600dpi
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
 }

--- a/examples/ipp-3d.test
+++ b/examples/ipp-3d.test
@@ -82,9 +82,11 @@
 
 	EXPECT job-ids-supported OF-TYPE boolean IN-GROUP printer-attributes-tag WITH-VALUE true
 
-	EXPECT ?material-diameter-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag
+	EXPECT ?material-amount-units-supported OF-TYPE keyword WITH-VALUE "/^(g|kg|l|ml|mm)\$/" 
 
-	EXPECT material-purpose-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT ?material-diameter-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag 
+
+	EXPECT material-purpose-supported OF-TYPE keyword IN-GROUP printer-attributes-tag 
 
 	EXPECT ?material-rate-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag
 	EXPECT ?material-rate-units-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
@@ -101,11 +103,18 @@
 	EXPECT materials-col-default/material-key OF-TYPE keyword
 	EXPECT materials-col-default/material-name OF-TYPE name
 	EXPECT materials-col-default/material-type OF-TYPE keyword
+	EXPECT materials-col-default/material-fill-density OF-TYPE integer    
+	EXPECT materials-col-default/material-purpose OF-TYPE name             
+	EXPECT materials-col-default/material-shell-thickness OF-TYPE integer 
 
 	EXPECT materials-col-ready OF-TYPE collection IN-GROUP printer-attributes-tag
 	EXPECT materials-col-ready/material-key OF-TYPE keyword
 	EXPECT materials-col-ready/material-name OF-TYPE name
 	EXPECT materials-col-ready/material-type OF-TYPE keyword
+
+	EXPECT material-diameter-ready IF-DEFINED HAVE_MATERIAL_DIAMETER DEFINE-VALUE MATERIAL_DIAMETER  
+	EXPECT materials-col-ready/material-type WITH-VALUE "pla" DEFINE-MATCH SUPPORTS_PLA_MATERIAL     
+	EXPECT materials-col-ready/material-type WITH-VALUE "abs" DEFINE-MATCH SUPPORTS_ABS_MATERIAL	 
 
  	EXPECT materials-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
 	EXPECT materials-col-supported WITH-VALUE "material-fill-density"
@@ -114,6 +123,7 @@
 	EXPECT materials-col-supported WITH-VALUE "material-purpose"
 	EXPECT materials-col-supported WITH-VALUE "material-shell-thickness"
 	EXPECT materials-col-supported WITH-VALUE "material-type"
+
 
 	EXPECT max-materials-col-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0
 
@@ -144,6 +154,8 @@
 	EXPECT print-accuracy-supported/x-accuracy OF-TYPE integer
 	EXPECT print-accuracy-supported/y-accuracy OF-TYPE integer
 	EXPECT print-accuracy-supported/z-accuracy OF-TYPE integer
+
+	EXPECT print-accuracy-default/accuracy-units WITH-VALUE "mm" DEFINE-MATCH SUPPORTS_MM_UNIT
 
 	EXPECT print-base-default OF-TYPE keyword IN-GROUP printer-attributes-tag
 	EXPECT print-base-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
@@ -178,6 +190,8 @@
 
 	EXPECT printer-organizational-unit OF-TYPE text IN-GROUP printer-attributes-tag
 
+	EXPECT printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag
+
 	EXPECT printer-volume-supported OF-TYPE collection IN-GROUP printer-attributes-tag
 	EXPECT printer-volume-supported/x-dimension OF-TYPE integer WITH-VALUE >0
 	EXPECT printer-volume-supported/y-dimension OF-TYPE integer WITH-VALUE >0
@@ -189,6 +203,7 @@
 	EXPECT printer-xri-supported/xri-uri OF-TYPE uri WITH-VALUE-FROM printer-uri-supported
 
 	EXPECT which-jobs-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+
 
 	# Conditional stuff...
 	EXPECT document-format-supported WITH-VALUE "application/pdf" DEFINE-MATCH HAVE_PDF
@@ -213,7 +228,14 @@
 	EXPECT materials-col-supported WITH-VALUE "material-rate-units" IF-DEFINED HAVE_MATERIAL_RATE
 	EXPECT materials-col-supported WITH-VALUE "material-temperature" DEFINE-MATCH HAVE_MATERIAL_TEMPERATURE
 
-	EXPECT material-diameter-supported IF-DEFINED HAVE_MATERIAL_DIAMETER
+	EXPECT materials-col-supported WITH-VALUE "materials-color" DEFINE-MATCH HAVE_MATERIAL_COLOR
+
+	EXPECT materials-col-supported WITH-VALUE "material-diameter" IF-DEFINED USES_FILAMENT_MATERIAL  #Printers that use filament material must support this attribute.
+	EXPECT materials-col-supported WITH-VALUE "material-temperature" IF-DEFINED SUPPORTS_MATERIAL_TEMPERATURE_CONTROL
+
+	EXPECT material-amount-units-supported IF-DEFINED HAVE_MATERIAL_AMOUNT  
+
+	EXPECT material-diameter-supported IF-DEFINED HAVE_MATERIAL_DIAMETER 
 
 	EXPECT material-rate-supported IF-DEFINED HAVE_MATERIAL_RATE
 	EXPECT material-rate-units-supported IF-DEFINED HAVE_MATERIAL_RATE
@@ -222,6 +244,24 @@
 
 	EXPECT platform-temperature-supported DEFINE-MATCH HAVE_PLATFORM_TEMPERATURE
 	EXPECT platform-temperature-default IF-DEFINED HAVE_PLATFORM_TEMPERATURE
+
+	# Job template attributes for specific tests
+	EXPECT multiple-object-handling WITH-VALUE "auto" DEFINE-MATCH OPTIONAL_AUTO_MUTIPLE_OBJECT_HANDLING
+	EXPECT multiple-object-handling WITH-VALUE "best-fit" DEFINE-MATCH OPTIONAL_BESTFIT_MUTIPLE_OBJECT_HANDLING
+	EXPECT multiple-object-handling WITH-VALUE "best-quality" DEFINE-MATCH OPTIONAL_BESTQUALITY_MUTIPLE_OBJECT_HANDLING
+	EXPECT multiple-object-handling WITH-VALUE "best-speed" DEFINE-MATCH OPTIONAL_BESTSPEED_MUTIPLE_OBJECT_HANDLING
+	EXPECT multiple-object-handling WITH-VALUE "one-at-a-time" DEFINE-MATCH OPTIONAL_ONEATATIME_MUTIPLE_OBJECT_HANDLING
+	EXPECT print-supports-supported WITH-VALUE "none" DEFINE-MATCH OPTIONAL_STANDARD_PRINTSUPPORTS
+	EXPECT print-supports-supported WITH-VALUE "material" DEFINE-MATCH OPTIONAL_NONE_PRINTSUPPORTS
+	EXPECT print-supports-supported WITH-VALUE "standard" DEFINE-MATCH OPTIONAL_MATERIAL_PRINTSUPPORTS
+	EXPECT print-base WITH-VALUE "standard" DEFINE-MATCH OPTIONAL_STANDARD_PRINTBASE
+	EXPECT print-base WITH-VALUE "none" DEFINE-MATCH OPTIONAL_NONE_PRINTBASE
+	EXPECT print-base WITH-VALUE "brim" DEFINE-MATCH OPTIONAL_BRIM_PRINTBASE
+	EXPECT print-base WITH-VALUE "raft" DEFINE-MATCH OPTIONAL_RAFT_PRINTBASE
+	EXPECT print-base WITH-VALUE "skirt" DEFINE-MATCH OPTIONAL_SKIRT_PRINTBASE
+
+
+
 }
 
 
@@ -244,7 +284,7 @@
 	EXPECT printer-config-change-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag
 	EXPECT printer-config-change-time OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1
 	EXPECT printer-is-accepting-jobs OF-TYPE boolean IN-GROUP printer-attributes-tag
-	EXPECT printer-state OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUES 3,4,5
+	EXPECT printer-state OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
 	EXPECT printer-state-change-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag
 	EXPECT printer-state-change-time OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1
 	EXPECT printer-up-time OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0
@@ -299,6 +339,17 @@
 	ATTR name job-name "IPP 3D Test Job"
 
 	STATUS successful-ok
+
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
 }
 {
 	NAME "Send-Document: IPP 3D Test Document"
@@ -307,10 +358,11 @@
 	ATTR charset attributes-charset utf-8
 	ATTR naturalLanguage attributes-natural-language en
 	ATTR uri printer-uri $uri
-	ATTR integer job-id $job_id
+	ATTR integer job-id $job-id
 	ATTR name requesting-user-name $user
 	ATTR name document-name "IPP 3D Test Document"
 	ATTR mimeMediaType document-format "model/3mf"
+	ATTR boolean last-document true
 
 	FILE $filename
 
@@ -325,13 +377,13 @@
 	ATTR charset attributes-charset utf-8
 	ATTR naturalLanguage attributes-natural-language en
 	ATTR uri printer-uri $uri
-	ATTR integer job-id $job_id
+	ATTR integer job-id $job-id
 	ATTR name requesting-user-name $user
 	ATTR keyword requested-attributes job-state
 
 	STATUS successful-ok
 
-        # Repeat while we are not canceled, aborted, or completed...
+    # Repeat while we are not canceled, aborted, or completed...
 	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE <7 REPEAT-MATCH
 }
 
@@ -344,7 +396,7 @@
 	ATTR charset attributes-charset utf-8
 	ATTR naturalLanguage attributes-natural-language en
 	ATTR uri printer-uri $uri
-	ATTR integer job-id $job_id
+	ATTR integer job-id $job-id
 	ATTR name requesting-user-name $user
 	ATTR keyword requested-attributes all
 
@@ -356,7 +408,7 @@
 	EXPECT date-time-at-creation OF-TYPE dateTime IN-GROUP job-attributes-tag
 	EXPECT date-time-at-processing OF-TYPE dateTime IN-GROUP job-attributes-tag
 	EXPECT document-format-supplied OF-TYPE mimeMediaType IN-GROUP job-attributes-tag WITH-VALUE "model/3mf"
-	EXPECT document-name-supplied OF-TYPE name IN-GROUP job-attributes-tag "IPP 3D Test Document"
+	EXPECT document-name-supplied OF-TYPE name IN-GROUP job-attributes-tag WITH-VALUE "IPP 3D Test Document"
 	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
 	EXPECT job-name OF-TYPE name IN-GROUP job-attributes-tag WITH-VALUE "IPP 3D Test Job"
 	EXPECT job-originating-user-name OF-TYPE name IN-GROUP job-attributes-tag
@@ -378,3 +430,1218 @@
 	EXPECT time-at-creation OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
 	EXPECT time-at-processing OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
 }
+
+# Test Validate-Job operation
+{
+	NAME "Validate-Job Operation"
+	OPERATION Validate-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	STATUS successful-ok
+}
+
+# Test Cancel-Job operation
+{
+	NAME "RFC 8011 section 4.3.3: Cancel-Job Operation (completed job)"
+	OPERATION Cancel-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS client-error-not-possible
+}
+
+# Create a test job and wait for completion...
+{
+	NAME "Create-Job: IPP 3D Test Job"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name "IPP 3D Test Job"
+
+	STATUS successful-ok
+
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	NAME "Send-Document: IPP 3D Test Document"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name "IPP 3D Test Document"
+	ATTR mimeMediaType document-format "model/3mf"
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+}
+{
+	DELAY 30
+
+	NAME "Get-Job-Attributes: Wait for Completion"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes job-state
+
+	STATUS successful-ok
+
+    # Repeat while we are not canceled, aborted, or completed...
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE <7 REPEAT-MATCH
+}
+
+# Test Get-Jobs operation
+{
+	NAME "Get-Jobs Operation (requested-attributes)"
+	OPERATION Get-Jobs
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes all
+
+	EXPECT compression-supplied OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT date-time-at-completed OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT date-time-at-creation OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT date-time-at-processing OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT document-format-supplied OF-TYPE mimeMediaType IN-GROUP job-attributes-tag WITH-VALUE "model/3mf"
+	EXPECT document-name-supplied OF-TYPE name IN-GROUP job-attributes-tag WITH-VALUE "IPP 3D Test Document"
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-name OF-TYPE name IN-GROUP job-attributes-tag WITH-VALUE "IPP 3D Test Job"
+	EXPECT job-originating-user-name OF-TYPE name IN-GROUP job-attributes-tag
+	EXPECT job-printer-up-time OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-printer-uri OF-TYPE uri IN-GROUP job-attributes-tag WITH-VALUE "$uri"
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 9 # completed
+	EXPECT job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag
+	EXPECT job-uuid OF-TYPE uri IN-GROUP job-attributes-tag WITH-VALUE "/^urn:uuid:/"
+	EXPECT materials-col-actual OF-TYPE collection IN-GROUP job-attributes-tag
+	EXPECT multiple-object-handling-actual OF-TYPE collection IN-GROUP job-attributes-tag IF-DEFINED HAVE_PDF
+	EXPECT platform-temperature-actual OF-TYPE integer IN-GROUP job-attributes-tag IF-DEFINED HAVE_PLATFORM_TEMPERATURE
+	EXPECT print-accuracy-actual OF-TYPE collection IN-GROUP job-attributes-tag
+	EXPECT print-base-actual OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT print-objects-actual OF-TYPE collection IN-GROUP job-attributes-tag IF-DEFINED HAVE_PDF
+	EXPECT print-supports-actual OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT time-at-completed OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT time-at-creation OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT time-at-processing OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+}
+
+# Make the printer display a message and beep
+{
+	# The name of the test...
+	NAME "Identify Printer with Message and Beep"
+
+	# The operation to use
+	OPERATION Identify-Printer
+
+	# Attributes, starting in the operation group...
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword identify-actions sound,display
+	ATTR text message "Hello\, World!"
+
+	# What statuses are OK?
+	STATUS successful-ok
+	STATUS successful-ok-ignored-or-substituted-attributes
+}
+
+
+#Creating jobs. These jobs will be canceled at once by the Cancel-My-Jobs operation below
+# Create a test job 1
+{
+	NAME "Create-Job: IPP 3D Test Job"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name "IPP 3D Test Job"
+
+	STATUS successful-ok
+
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_FIRSTCANCEL
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+# Create a test job 2
+{
+	NAME "Create-Job: IPP 3D Test Job"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name "IPP 3D Test Job"
+
+	STATUS successful-ok
+
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_SECONDCANCEL
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+# Test Cancel-My-Jobs operation
+{
+	NAME "PWG 5100.11 section 5.2: Cancel-My-Jobs Operation"
+	OPERATION Cancel-My-Jobs
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-ids $JOBID_FIRSTCANCEL, $JOBID_SECONDCANCEL
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+	STATUS client-error-not-authorized
+}
+
+
+# Create a test job to be cancelled by the Close-Job operation 
+{
+	NAME "Create-Job: IPP 3D Test Job"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name "IPP 3D Test Job"
+
+	STATUS successful-ok
+
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_CLOSEJOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	NAME "Send-Document: IPP 3D Test Document 1"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_CLOSEJOB
+	ATTR name requesting-user-name $user
+	ATTR name document-name "IPP 3D Test Document"
+	ATTR mimeMediaType document-format "model/3mf"
+
+	FILE $filename
+
+	STATUS successful-ok
+}
+{
+	NAME "Send-Document: IPP 3D Test Document 2"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_CLOSEJOB
+	ATTR name requesting-user-name $user
+	ATTR name document-name "IPP 3D Test Document"
+	ATTR mimeMediaType document-format "model/3mf"
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+}
+
+#Close-Job operation
+{
+	NAME "Section 5.3 PWG 5100.11: Close-Job Operation"
+	OPERATION Close-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_CLOSEJOB
+	ATTR name requesting-user-name $user
+
+
+	STATUS successful-ok
+	STATUS client-error-forbidden
+	STATUS client-error-not-authenticated
+	STATUS client-error-not-authorized
+}
+
+
+# Create a test job using materials-col job-template-attribute (material-type=pla)
+{
+	SKIP-IF-NOT-DEFINED SUPPORTS_PLA_MATERIAL
+	SKIP-IF-NOT-DEFINED MATERIAL_DIAMETER
+
+	NAME "Create-Job: IPP 3D Test Job with materials-col job-template-attribute (material-type=pla)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection materials-col {
+		MEMBER keyword material-type "pla"
+		MEMBER integer material-diameter $MATERIAL-DIAMETER
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED SUPPORTS_PLA_MATERIAL
+	SKIP-IF-NOT-DEFINED MATERIAL_DIAMETER
+
+	NAME "Send-Document: IPP 3D Test Document for test with materials-col job-template-attribute (material-type=pla)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with materials-col job-template-attribute (material-type=abs)
+{
+	SKIP-IF-NOT-DEFINED SUPPORTS_ABS_MATERIAL
+	SKIP-IF-NOT-DEFINED MATERIAL_DIAMETER
+
+	NAME "Create-Job: IPP 3D Test Job with materials-col job-template-attribute (material-type=abs)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection materials-col {
+		MEMBER keyword material-type "abs"
+		MEMBER integer material-diameter $MATERIAL-DIAMETER
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED SUPPORTS_PLA_MATERIAL
+	SKIP-IF-NOT-DEFINED MATERIAL_DIAMETER
+
+	NAME "Send-Document: IPP 3D Test Document for test with materials-col job-template-attribute (material-type=abs)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'auto' multiple-object-handling
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_AUTO_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Create-Job: IPP 3D Test Job using mutiple-object-handling job-template-attribute (auto)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword multiple-object-handling "auto"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_AUTO_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Send-Document: IPP 3D Test Document for test with mutiple-object-handling job-template-attribute (auto)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'best-fit' multiple-object-handling
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_BESTFIT_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Create-Job: IPP 3D Test Job using mutiple-object-handling job-template-attribute (best-fit)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword multiple-object-handling "best-fit"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_BESTFIT_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Send-Document: IPP 3D Test Document for test using mutiple-object-handling job-template-attribute (best-fit)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+
+# Create a test job with 'best-quality' multiple-object-handling
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_BESTQUALITY_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Create-Job: IPP 3D Test Job using mutiple-object-handling job-template-attribute (best-quality)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword multiple-object-handling "best-quality"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_BESTQUALITY_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Send-Document: IPP 3D Test Document for test using mutiple-object-handling job-template-attribute (best-quality)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'best-speed' multiple-object-handling
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_BESTSPEED_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Create-Job: IPP 3D Test Job using mutiple-object-handling job-template-attribute (best-speed)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword multiple-object-handling "best-speed"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_BESTSPEED_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Send-Document: IPP 3D Test Document for test using mutiple-object-handling job-template-attribute (best-speed)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'one-at-a-time' multiple-object-handling
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_ONEATATIME_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Create-Job: IPP 3D Test Job using mutiple-object-handling job-template-attribute (one-at-a-time)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword multiple-object-handling "one-at-a-time"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED HAVE_PDF
+	SKIP-IF-NOT-DEFINED OPTIONAL_ONEATATIME_MUTIPLE_OBJECT_HANDLING
+
+	NAME "Send-Document: IPP 3D Test Document for test using mutiple-object-handling job-template-attribute (one-at-a-time)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+#Create a conditional test job with platform-temperature 60 degree c
+{
+	SKIP-IF-NOT-DEFINED HAVE_PLATFORM_TEMPERATURE
+
+	NAME "Create-Job: IPP 3D Test Job using platform-temperature job-template-attribute (60 degree c)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer platform-temperature 60
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED HAVE_PLATFORM_TEMPERATURE
+
+	NAME "Send-Document: IPP 3D Test Document for test using mutiple-object-handling job-template-attribute (one-at-a-time)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+} 
+
+
+
+# Create a test job using print-accuracy job-template-attribute (unit =mm, accuracy =0)
+{
+	SKIP-IF-NOT-DEFINED SUPPORTS_MM_UNIT
+
+	NAME "Create-Job: IPP 3D Test Job with printer-accuracy job-template-attribute (unit =mm, accuracy =0)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection print-accuracy {
+		MEMBER keyword accuracy-units "mm"
+		MEMBER integer x-accuracy 0
+		MEMBER integer y-accuracy 0
+		MEMBER integer z-accuracy 0
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED SUPPORTS_MM_UNIT
+
+	NAME "Send-Document: IPP 3D Test Document for test with materials-col job-template-attribute (material-type=pla)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+
+
+
+
+# Create a test job with 'none' print-base 
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_NONE_PRINTBASE
+
+	NAME "Create-Job: IPP 3D Test Job using print-base job-template-attribute (none)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-base "none"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_NONE_PRINTBASE
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-base job-template-attribute (none)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'brim' print-base
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_BRIM_PRINTBASE
+
+	NAME "Create-Job: IPP 3D Test Job using print-base job-template-attribute (none)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-base "brim"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_BRIM_PRINTBASE
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-base job-template-attribute (brim)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'raft' print-base
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_RAFT_PRINTBASE
+
+	NAME "Create-Job: IPP 3D Test Job using print-base job-template-attribute (raft)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-base "raft"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_RAFT_PRINTBASE
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-base job-template-attribute (raft)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'skirt' print-base
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SKIRT_PRINTBASE
+
+	NAME "Create-Job: IPP 3D Test Job using print-base job-template-attribute (skirt)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-base "skirt"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_SKIRT_PRINTBASE
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-base job-template-attribute (skirt)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'standard' print-base
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STANDARD_PRINTBASE
+
+	NAME "Create-Job: IPP 3D Test Job using print-base job-template-attribute (standard)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-base "standard"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STANDARD_PRINTBASE
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-base job-template-attribute (standard)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'standard' print-supports
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STANDARD_PRINTSUPPORTS
+
+	NAME "Create-Job: IPP 3D Test Job using print-supports job-template-attribute (standard)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-supports "standard"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_STANDARD_PRINTSUPPORTS
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-supports job-template-attribute (standard)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with 'none' print-supports
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_NONE_PRINTSUPPORTS
+
+	NAME "Create-Job: IPP 3D Test Job using print-supports job-template-attribute (none)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-supports "none"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_NONE_PRINTSUPPORTS
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-supports job-template-attribute (none)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+
+
+# Create a test job with 'material' print-supports
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_MATERIAL_PRINTSUPPORTS
+
+	NAME "Create-Job: IPP 3D Test Job using print-supports job-template-attribute (material)"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR keyword print-supports "material"
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_MATERIAL_PRINTSUPPORTS
+
+	NAME "Send-Document: IPP 3D Test Document for test using print-supports job-template-attribute (material)"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+}
+

--- a/examples/pwg5100.15.test
+++ b/examples/pwg5100.15.test
@@ -1,0 +1,593 @@
+#Test file for the Ipp Faxout Service
+#Variables expected from user HAVE_SCANNING_ACCESSORIES, HAVE_COLOR_SCANNING_ACCESSORIES, HAVE_DUPLEX_SCANNING_ACCESSORIES
+
+# Regular expressions for URI schemes:
+#
+#   HTTP_URI_SCHEME - Matches strings beginning with http:// or https://
+#   IPP_URI_SCHEME  - Matches strings beginning with ipp:// or ipps://
+
+DEFINE HTTP_URI_SCHEME "/^https?://.+$$/"
+DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
+
+# Test required printer description attribute support.
+#
+# Required by: PWG 5100.15
+{
+	NAME "Required Operations and Attributes"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format application/octet-stream
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+
+	# Operations
+	EXPECT operations-supported WITH-VALUE 0x0004 # Validate-Job
+	EXPECT operations-supported WITH-VALUE 0x0005 # Create-Job
+	EXPECT operations-supported WITH-VALUE 0x0006 # Send-Document
+	EXPECT operations-supported WITH-VALUE 0x0008 # Cancel-Job
+	EXPECT operations-supported WITH-VALUE 0x0009 # Get-Job-Attributes
+	EXPECT operations-supported WITH-VALUE 0x000a # Get-Jobs
+	EXPECT operations-supported WITH-VALUE 0x000b # Get-Printer-Attributes
+	EXPECT operations-supported WITH-VALUE 0x0039 # Cancel-My-Jobs
+	EXPECT operations-supported WITH-VALUE 0x003b # Close-Job
+	EXPECT operations-supported WITH-VALUE 0x003c # Identify-Printer
+	EXPECT operations-supported WITH-VALUE 0x003E IF-DEFINED HAVE_SCANNING_ACCESSORIES DEFINE-MATCH ADD_DOCUMENT_IMAGES_SUPPORTED
+
+
+
+
+	# Printer description attributes
+	EXPECT charset-configured OF-TYPE charset IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT charset-supported OF-TYPE charset IN-GROUP printer-attributes-tag WITH-VALUE utf-8
+    EXPECT color-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deflate" DEFINE-MATCH HAVE_DEFLATE
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "gzip" DEFINE-MATCH HAVE_GZIP
+	EXPECT copies-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
+ 	EXPECT copies-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag
+ 	EXPECT document-format-default OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag
+	EXPECT document-format-supported WITH-VALUE "image/jpeg"
+	EXPECT document-format-supported WITH-VALUE "image/pwg-raster"
+	EXPECT document-format-supported WITH-VALUE "/^(application/pdf|application/openxps)$/" DEFINE-MATCH PDF_OR_OPENXPS
+	EXPECT generated-natural-language-supported OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag
+	EXPECT ipp-features-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT ipp-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE 1.1
+	EXPECT job-ids-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE true
+	EXPECT media-bottom-margin-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-ALL-VALUES >-1
+	EXPECT media-left-margin-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-ALL-VALUES >-1
+	EXPECT media-right-margin-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-ALL-VALUES >-1
+	EXPECT media-top-margin-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-ALL-VALUES >-1
+	EXPECT media-col-database OF-TYPE collection IN-GROUP printer-attributes-tag
+	EXPECT media-col-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT media-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT media-default OF-TYPE no-value|keyword|name IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT media-size-supported OF-TYPE collection IN-GROUP printer-attributes-tag
+	EXPECT media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag
+	EXPECT multiple-document-handling-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/" IF-DEFINED PDF_OR_OPENXPS
+	EXPECT multiple-document-jobs-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT multiple-operation-time-out OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT multiple-operation-time-out-action OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(abort-job|hold-job|process-job)$/"
+	EXPECT natural-language-configured OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag
+	EXPECT page-ranges-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE true IF-DEFINED PDF_OR_OPENXPS
+	EXPECT print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
+	EXPECT print-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5	
+	EXPECT printer-alert OF-TYPE octetString IN-GROUP printer-attributes-tag
+	EXPECT printer-alert-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-alert
+	EXPECT printer-config-change-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-config-change-time OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >-1
+	EXPECT printer-current-time OF-TYPE datetime IN-GROUP printer-attributes-tag 
+	EXPECT printer-device-id OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^([-A-Za-z ]+:[^;]*;)+$/"
+	EXPECT printer-geo-location OF-TYPE uri|unknown IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^geo:/"
+	EXPECT printer-get-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-format"
+	EXPECT printer-get-attributes-supported WITH-VALUE "destination-uri"
+	EXPECT printer-icons OF-TYPE uri IN-GROUP printer-attributes-tag
+	EXPECT printer-info OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-is-accepting-jobs OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-location OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-make-and-model OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-more-info OF-TYPE uri IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "$HTTP_URI_SCHEME"
+	EXPECT printer-name OF-TYPE name IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-organization OF-TYPE text IN-GROUP printer-attributes-tag
+	EXPECT printer-organizational-unit OF-TYPE text IN-GROUP printer-attributes-tag
+	EXPECT printer-resolution-default OF-TYPE resolution IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag
+	EXPECT printer-state-change-time OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >-1
+	EXPECT printer-state-change-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-state-message OF-TYPE text IN-GROUP printer-attributes-tag
+	EXPECT printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT printer-up-time OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT printer-uri-supported OF-TYPE uri IN-GROUP printer-attributes-tag SAME-COUNT-AS uri-security-supported WITH-ALL-VALUES "$IPP_URI_SCHEME"
+	EXPECT printer-uuid OF-TYPE uri IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^urn:uuid:[0-9A-Fa-f]{8,8}-[0-9A-Fa-f]{4,4}-[0-9A-Fa-f]{4,4}-[0-9A-Fa-f]{4,4}-[0-9A-Fa-f]{12,12}/"
+	EXPECT pwg-raster-document-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag
+	EXPECT pwg-raster-document-type-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT queued-job-count OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT uri-security-supported OF-TYPE keyword IN-GROUP printer-attributes-tag SAME-COUNT-AS uri-authentication-supported
+	EXPECT uri-authentication-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT which-jobs-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+
+
+	EXPECT confirmation-sheet-print-default OF-TYPE boolean IN-GROUP printer-attributes-tag 
+	EXPECT cover-sheet-info-default OF-TYPE collection|unknown IN-GROUP printer-attributes-tag IF-DEFINED PDF_OR_OPENXPS
+	EXPECT cover-sheet-info-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED PDF_OR_OPENXPS
+	EXPECT cover-sheet-info-supported WITH-VALUE "logo" DEFINE-MATCH LOGO_SUPPORTED
+	EXPECT destination-uri-schemes-supported OF-TYPE uriScheme IN-GROUP printer-attributes-tag WITH-VALUE "tel" 
+	EXPECT destination-uris-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "destination-uri"
+	EXPECT from-name-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1,<1024
+	EXPECT input-attributes-default OF-TYPE collection IN-GROUP printer-attributes-tag IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-attributes-supported WITH-VALUE "input-color-mode" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-attributes-supported WITH-VALUE "input-media" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-attributes-supported WITH-VALUE "input-quality" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-attributes-supported WITH-VALUE "input-source" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-color-mode-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-color-mode-supported WITH-VALUE "monochrome" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-color-mode-supported WITH-VALUE "bi-level" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT input-content-type-supported OF-TYPE keyword IN-GROUP printer-attributes-tag 
+	EXPECT input-film-scan-mode-supported OF-TYPE keyword IN-GROUP printer-attributes-tag 
+	EXPECT input-media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE "auto" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED 
+	EXPECT input-orientation-requested-supported OF-TYPE enum IN-GROUP printer-attributes-tag 
+	EXPECT input-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE "4" IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT ?input-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag 
+	EXPECT input-scan-regions-supported OF-TYPE collection IN-GROUP printer-attributes-tag 
+	EXPECT input-scan-regions-supported/x-dimension OF-TYPE rangeOfInteger
+	EXPECT input-scan-regions-supported/x-origin OF-TYPE rangeOfInteger
+	EXPECT input-scan-regions-supported/y-dimension OF-TYPE rangeOfInteger
+	EXPECT input-scan-regions-supported/y-origin OF-TYPE rangeOfInteger
+	EXPECT input-source-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT logo-uri-formats-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "image/jpeg" IF-DEFINED LOGO_SUPPORTED
+	EXPECT logo-uri-schemes-supported OF-TYPE uriScheme IN-GROUP printer-attributes-tag IF-DEFINED LOGO_SUPPORTED
+	EXPECT message-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1,<1024
+	EXPECT multiple-destination-uris-supported OF-TYPE boolean IN-GROUP printer-attributes-tag 
+	EXPECT number-of-retries-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED IS_SPOOLING_DEVICE
+	EXPECT number-of-retries-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED IS_SPOOLING_DEVICE
+	EXPECT number-of-retries-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1,<1024
+	EXPECT printer-fax-log-uri OF-TYPE uri IN-GROUP printer-attributes-tag 
+	EXPECT ?printer-fax-modem-info OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-fax-modem-name
+	EXPECT ?printer-fax-modem-name OF-TYPE name IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-fax-modem-number
+	EXPECT ?printer-fax-modem-number OF-TYPE uri IN-GROUP printer-attributes-tag 
+	EXPECT retry-interval-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED IS_SPOOLING_DEVICE
+	EXPECT retry-interval-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED IS_SPOOLING_DEVICE
+	EXPECT retry-time-out-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED IS_SPOOLING_DEVICE
+	EXPECT retry-time-out-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED IS_SPOOLING_DEVICE
+	EXPECT subject-supported OF-TYPE interger IN-GROUP printer-attributes-tag WITH-VALUE >-1,<1024 
+	EXPECT to-name-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1,<1024
+
+#Additional Values and Semantics...
+	EXPECT ipp-features-supported WITH-VALUE "faxout"
+
+}
+
+#Get-Printer-Attributes test to check the 'color' value of the input-content-supported
+{
+	SKIP-IF-NOT-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	SKIP-IF-NOT-DEFINED HAVE_COLOR_SCANNING_ACCESSORIES 
+
+	NAME "Required Operations and Attributes"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format application/octet-stream
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+	EXPECT input-color-mode-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "color" 
+}
+
+#Get-Printer-Attributes test to check the input-sides-supported printer description attribute
+{
+	SKIP-IF-NOT-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	SKIP-IF-NOT-DEFINED HAVE_DUPLEX_SCANNING_ACCESSORIES 
+
+	NAME "Required Operations and Attributes"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format application/octet-stream
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+	EXPECT input-sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag  
+}
+
+
+#Creating a job to later use the get-job-attributes operation to test the required job description attributes
+{
+	NAME "create-job"
+
+	OPERATION create-job
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS successful-ok-ignored-or-substituted-attributes
+
+	EXPECT job-id
+	EXPECT job-uri
+}
+{
+	NAME "send-document"
+
+	OPERATION send-document
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR mimetype document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS successful-ok-ignored-or-substituted-attributes
+}
+{
+	DELAY 30
+
+	NAME "Get-Job-Attributes: Wait for Completion"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes job-state
+
+	STATUS successful-ok
+
+        # Repeat while we are not canceled, aborted, or completed...
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE <7 REPEAT-MATCH
+}
+
+
+# Test required Job Description/Status Attributes
+{
+	NAME "IPP Job Description/Status Attributes required for IPP Faxout Service"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+	# Job Status attributes
+	EXPECT compression-supplied OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT date-time-at-completed OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT date-time-at-creation OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT date-time-at-processing OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT document-format-supplied OF-TYPE mimeMediaType IN-GROUP job-attributes-tag
+	EXPECT document-name-supplied OF-TYPE name IN-GROUP job-attributes-tag 
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-name OF-TYPE name IN-GROUP job-attributes-tag COUNT 1
+	EXPECT job-originating-user-name OF-TYPE name IN-GROUP job-attributes-tag
+	EXPECT job-printer-up-time OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-printer-uri OF-TYPE uri IN-GROUP job-attributes-tag WITH-VALUE "$uri"
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 9 # completed
+	EXPECT job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag
+	EXPECT job-uuid OF-TYPE uri IN-GROUP job-attributes-tag WITH-VALUE "/^urn:uuid:/"
+	EXPECT time-at-completed OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT time-at-creation OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT time-at-processing OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-impressions-completed OF-TYPE integer|no-value IN-GROUP job-attributes-tag COUNT 1
+	EXPECT job-impressions OF-TYPE integer|no-value IN-GROUP job-attributes-tag COUNT 1
+	EXPECT destination-statuses OF-TYPE collection IN-GROUP job-attributes-tag SAME-COUNT-AS destination-uris
+	EXPECT destination-uri OF-TYPE uri IN-GROUP job-attributes-tag 
+	EXPECT images-completed OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT transmission-status OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 3,4,5,7,8,9
+	EXPECT input-attributes-actual OF-TYPE collection IN-GROUP job-attributes-tag IF-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	EXPECT document-format-version-supplied OF-TYPE text IN-GROUP job-attributes-tag WITH-VALUE "/^.{0,127}$$/"
+}
+
+
+
+# Test Create-Job and Add-Document-Images operations
+# Defined by: RFC 8011 section 4.2.4 and PWG 5100.15
+{
+	SKIP-IF-NOT-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.4: Create-Job Operation"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_ADD_DOCUMENT_IMAGES
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+#Testing the Add-Document-Images-Operation
+{
+	SKIP-IF-NOT-DEFINED ADD_DOCUMENT_IMAGES_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_ADD_DOCUMENT_IMAGES
+
+	NAME "PWG 5100.15 section 6.1: Add-Document-Images Operation"
+	OPERATION Add-Document-Images
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_ADD_DOCUMENT_IMAGES
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR uri document-uri $document-uri
+	ATTR boolean last-document true
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS client-error-attributes-or-values-not-supported
+
+	EXPECT document-number OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0
+}
+
+# Create a test job with destination-uris ( only destination-uri )
+{
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+
+	NAME "Create-Job: Testing sending print-jobs to a destination-uri"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection destination-uris {
+		MEMBER uri destination-uri $DESTINATION_URI_TO_DIAL
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+
+	NAME "Send-Document"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+}
+
+# Create a test job with destination-uris ( destination-uri, post-dial-string )
+{
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+	SKIP-IF-NOT-DEFINED POST_DIAL_STRING
+
+	NAME "Create-Job: Testing sending print-jobs using destination-uri and post-dial-string"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection destination-uris {
+		MEMBER uri destination-uri $DESTINATION_URI_TO_DIAL
+		MEMBER text post-dial-string $POST_DIAL_STRING
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+	SKIP-IF-NOT-DEFINED POST_DIAL_STRING
+
+	NAME "Send-Document"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+}
+
+
+# Create a test job with destination-uris ( destination-uri, pre-dial-string )
+{
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+	SKIP-IF-NOT-DEFINED PRE_DIAL_STRING
+
+	NAME "Create-Job: Testing sending print-jobs using destination-uri and pre-dial-string"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection destination-uris {
+		MEMBER uri destination-uri $DESTINATION_URI_TO_DIAL
+		MEMBER text pre-dial-string $PRE_DIAL_STRING
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+	SKIP-IF-NOT-DEFINED PRE_DIAL_STRING
+
+	NAME "Send-Document"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+}
+
+
+# Create a test job with destination-uris ( destination-uri, post-dial-string, t33-subaddress )
+{
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+	SKIP-IF-NOT-DEFINED POST_DIAL_STRING
+	SKIP-IF-NOT-DEFINED T33_SUBADDRESS
+
+	NAME "Create-Job: Testing sending print-jobs using destination-uri, post-dial-string and t33_subaddress"
+	OPERATION Create-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR collection destination-uris {
+		MEMBER uri destination-uri $DESTINATION_URI_TO_DIAL
+		MEMBER text post-dial-string $POST_DIAL_STRING
+		MEMBER integer t33-subaddress $T33_SUBADDRESS
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+
+}
+{
+
+	SKIP-IF-NOT-DEFINED DESTINATION_URI_TO_DIAL
+	SKIP-IF-NOT-DEFINED POST_DIAL_STRING
+	SKIP-IF-NOT-DEFINED T33_SUBADDRESS
+
+	NAME "Send-Document"
+	OPERATION Send-Document
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean last-document true
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+}
+
+
+

--- a/examples/pwg5100.16.test
+++ b/examples/pwg5100.16.test
@@ -1,0 +1,260 @@
+#The file contains Confromance tests for PWG 5100.16-2013 IPP Transaction-Based Printing Extensions besides containing print-job tests for the print-scaling, job-accounting-user-id, job-account-type job template attributes.
+
+#Get-Printer-Attributes operation
+{
+	NAME "Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	STATUS successful-ok
+
+	#operations
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag	
+	EXPECT operations-supported WITH-VALUE 0x0013 DEFINE-MATCH SET_PRINTER_ATTRIBUTES_SUPPORTED #Set-Printer-Attributes
+
+	#printer description attributes
+	EXPECT ?job-account-type-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag DEFINE-MATCH JOB_ACCOUNT_TYPE_SUPPORTED
+	EXPECT ?job-account-type-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED JOB_ACCOUNT_TYPE_SUPPORTED
+	EXPECT printer-dns-sd-name OF-TYPE name IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-kind OF-TYPE keyword|name IN-GROUP printer-attributes-tag 
+	EXPECT job-authorization-uri-supported OF-TYPE boolean IN-GROUP printer-attributes-tag IF-DEFINED JOB_AUTH_URI_OPERATION_ATTR_SUPPORTED
+	
+	EXPECT job-account-id-supported OF-TYPE boolean IN-GROUP printer-attributes-tag WITH-VALUE true COUNT 1 DEFINE-MATCH JOB_ACCOUNT_ID_SUPPORTED
+    EXPECT job-account-id-default OF-TYPE name|no-value IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED JOB_ACCOUNT_ID_SUPPORTED
+    EXPECT job-accounting-user-id-supported OF-TYPE boolean IN-GROUP printer-attributes-tag WITH-VALUE true COUNT 1 IF-DEFINED JOB_ACCOUNT_ID_SUPPORTED 
+    EXPECT job-accounting-user-id-default OF-TYPE name|no-value IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED JOB_ACCOUNT_ID_SUPPORTED
+	
+	EXPECT jpeg-k-octets-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED JFIF_SUPPORTED
+	EXPECT jpeg-x-dimension-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED JFIF_SUPPORTED
+	EXPECT jpeg-y-dimension-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED JFIF_SUPPORTED
+
+	EXPECT pdf-k-octets-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED DOCUMENT_MANAGEMENT_PDF
+	EXPECT pdf-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED DOCUMENT_MANAGEMENT_PDF WITH-VALUE "/^(adobe-1.3|adobe-1.4|adobe-1.5|adobe-1.6|iso-15930-1_2001|iso-15930-3_2002|iso-15930-4_2003|iso-15930-6_2003|iso-15930-3_2010|iso-15930-8_2010|iso-16612-2:2010|iso-19005-1_2005|iso-19005-2_2011|iso-19005-3_2012|iso-32000-1_2008|none|pwg-5102.3)$$/"
+	EXPECT printer-settable-attributes-supported WITH-VALUE "printer-kind" IF-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+	EXPECT printer-settable-attributes-supported WITH-VALUE "printer-dns-sd-name" IF-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+
+	#job-template attributes
+	EXPECT print-scaling-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|auto-fit|fill|fit|none)$$/"
+	EXPECT print-scaling-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(auto|auto-fit|fill|fit|none)$$/"
+
+	#Job template attributes for specific tests
+	EXPECT print-scaling-supported WITH-VALUE "auto" DEFINE-MATCH PRINT_SCALING_AUTO_SUPPORTED
+	EXPECT print-scaling-supported WITH-VALUE "auto-fit" DEFINE-MATCH PRINT_SCALING_AUTOFIT_SUPPORTED 
+	EXPECT print-scaling-supported WITH-VALUE "fill" DEFINE-MATCH PRINT_SCALING_FILL_SUPPORTED 
+	EXPECT print-scaling-supported WITH-VALUE "fit" DEFINE-MATCH PRINT_SCALING_FIT_SUPPORTED  	
+}
+
+#Print-Job test to check the support of job-account-user-id provided that job-account-id is supported. Both job-account-id and job-accounting-user-id are expected to be entered in the ipptool command using JOB_ACCOUNT_ID and JOB_ACCOUNTING_USER_ID
+{
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_ID_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_ID
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_USER_ID
+
+	NAME "Print-Job Operation with job-accounting-user-id job template attribute provided job-account-id is supported"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	GROUP job-attributes-tag
+	ATTR name job-account-id $JOB_ACCOUNT_ID
+	ATTR keyword job-accounting-user-id $JOB_ACCOUNTING_USER_ID
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#Print-Job to test the job-account-type job template attribute. To be defined as JOB_ACCOUNT_TYPE varaible in the ipptool command along with the JOB_ACCOUNT_ID
+{
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_ID_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_TYPE_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_TYPE
+	SKIP-IF-NOT-DEFINED JOB_ACCOUNT_ID
+
+	NAME "Print-Job Operation with job-account-type job template attribute"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	GROUP job-attributes-tag
+	ATTR name job-account-id $JOB_ACCOUNT_ID
+	ATTR keyword job-account-type $JOB_ACCOUNT_TYPE
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#Print-job tests with different values for print-scaling job-template attribute
+{
+	SKIP-IF-NOT-DEFINED PRINT_SCALING_AUTO_SUPPORTED
+	
+	NAME "Print-Job Operation with print-scaling job template attribute (auto)"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	GROUP job-attributes-tag
+	ATTR keyword print-scaling "auto"
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+{
+	SKIP-IF-NOT-DEFINED PRINT_SCALING_AUTOFIT_SUPPORTED
+
+	NAME "Print-Job Operation with print-scaling job template attribute (auto-fit)"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	GROUP job-attributes-tag
+	ATTR keyword print-scaling "auto-fit"
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED PRINT_SCALING_FILL_SUPPORTED
+	
+	NAME "Print-Job Operation with print-scaling job template attribute (fill)"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	GROUP job-attributes-tag
+	ATTR keyword print-scaling "fill"
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+{
+	SKIP-IF-NOT-DEFINED PRINT_SCALING_FIT_SUPPORTED
+
+	NAME "Print-Job Operation with print-scaling job template attribute (fit)"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR name document-name $filename
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	GROUP job-attributes-tag
+	ATTR keyword print-scaling "fit"
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}

--- a/examples/pwg5100.17.test
+++ b/examples/pwg5100.17.test
@@ -1,0 +1,300 @@
+#Testfile includes tests to check the support for the different printer description attributes and job description attributes of the IPP scan service. It also tests the Get-Next-Document-Data operation of the service followed by print-job tests along with the destination-uri attribute to specify a paritcular destination of the scan job.
+
+# User is expected to enter the HAVE_PUSH_SCAN, MUTIPLE_DOCUMENT_JOBS_SUPPORTED, SETTING_PRINTER_XRI_SUPPORTED, HAVE_DUPLEX_SCANNING_ACCESSORIES flags and DESTINATION_URI variable value to run the tests for the same.
+
+# Regular expressions for URI schemes:
+#
+#   HTTP_URI_SCHEME - Matches strings beginning with http:// or https://
+#   IPP_URI_SCHEME  - Matches strings beginning with ipp:// or ipps://
+
+DEFINE HTTP_URI_SCHEME "/^https?://.+$$/"
+DEFINE IPP_URI_SCHEME "/^ipps?://.+$$/"
+
+# Test required printer description attribute support and required operations.
+{
+	NAME "Required Operations and Attributes for IPP Scan Service"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format application/octet-stream
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+
+	# Operations
+	EXPECT operations-supported WITH-VALUE 0x0004 # Validate-Job
+	EXPECT operations-supported WITH-VALUE 0x0005 # Create-Job
+	EXPECT operations-supported WITH-VALUE 0x0008 # Cancel-Job
+	EXPECT operations-supported WITH-VALUE 0x0009 # Get-Job-Attributes
+	EXPECT operations-supported WITH-VALUE 0x000a # Get-Jobs
+	EXPECT operations-supported WITH-VALUE 0x000b # Get-Printer-Attributes
+	EXPECT operations-supported WITH-VALUE 0x000c # Hold-Job
+	EXPECT operations-supported WITH-VALUE 0x000d # Release-Job
+	EXPECT operations-supported WITH-VALUE 0x0039 # Cancel-My-Jobs
+	EXPECT operations-supported WITH-VALUE 0x003b # Close-Job
+	EXPECT operations-supported WITH-VALUE 0x003c # Identify-Printer
+	EXPECT operations-supported WITH-VALUE 0x004A # Get-Next-Document-Data
+
+	# Printer description attributes
+	EXPECT charset-configured OF-TYPE charset IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT charset-supported OF-TYPE charset IN-GROUP printer-attributes-tag WITH-VALUE utf-8
+    EXPECT color-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deflate" DEFINE-MATCH HAVE_DEFLATE
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "gzip" DEFINE-MATCH HAVE_GZIP
+	EXPECT copies-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 1
+ 	EXPECT copies-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE 1
+ 	EXPECT destination-accesses-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_PUSH_SCAN
+ 	EXPECT document-format-default OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag
+	EXPECT document-format-supported WITH-VALUE "image/jpeg"
+	EXPECT document-format-supported WITH-VALUE "image/pwg-raster"
+	EXPECT document-format-supported WITH-VALUE "/^(application/pdf|application/openxps)$/" DEFINE-MATCH PDF_OR_OPENXPS
+	EXPECT destination-uri-schemes-supported OF-TYPE uriScheme IN-GROUP printer-attributes-tag WITH-VALUE "tel" 
+	EXPECT generated-natural-language-supported OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag
+	EXPECT input-attributes-default OF-TYPE collection IN-GROUP printer-attributes-tag
+	EXPECT input-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT input-color-mode-supported OF-TYPE keyword IN-GROUP printer-attributes-tag 
+	EXPECT input-media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE "auto"
+	EXPECT input-orientation-requested-supported OF-TYPE enum IN-GROUP printer-attributes-tag
+	EXPECT input-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE "4" 
+	EXPECT ?input-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag 
+	EXPECT input-source-supported OF-TYPE keyword IN-GROUP printer-attributes-tag 
+	EXPECT ipp-features-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT ipp-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE 1.1
+	EXPECT job-ids-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE true
+	EXPECT multiple-destination-uris-supported OF-TYPE boolean IN-GROUP printer-attributes-tag 
+	EXPECT multiple-document-handling-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/" IF-DEFINED MUTIPLE_DOCUMENT_JOBS_SUPPORTED
+	EXPECT multiple-document-jobs-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT multiple-operation-time-out OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0 IF-DEFINED MUTIPLE_DOCUMENT_JOBS_SUPPORTED
+	EXPECT multiple-operation-time-out-action OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(abort-job|hold-job|process-job)$/" IF-DEFINED MUTIPLE_DOCUMENT_JOBS_SUPPORTED
+	EXPECT natural-language-configured OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT number-of-retries-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1 
+	EXPECT number-of-retries-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_PUSH_SCAN
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-number"
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "pages"
+	EXPECT printer-device-id OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^([-A-Za-z ]+:[^;]*;)+$/"
+	EXPECT printer-geo-location OF-TYPE uri|unknown IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^geo:/"
+	EXPECT printer-get-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-format"
+	EXPECT printer-get-attributes-supported WITH-VALUE "destination-uri"
+	EXPECT printer-icons OF-TYPE uri IN-GROUP printer-attributes-tag
+	EXPECT printer-info OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-location OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-make-and-model OF-TYPE text IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-more-info OF-TYPE uri IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "$HTTP_URI_SCHEME"
+	EXPECT printer-name OF-TYPE name IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^.{0,127}$$/"
+	EXPECT printer-organization OF-TYPE text IN-GROUP printer-attributes-tag
+	EXPECT printer-organizational-unit OF-TYPE text IN-GROUP printer-attributes-tag
+	EXPECT retry-interval-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED HAVE_PUSH_SCAN
+	EXPECT retry-interval-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED HAVE_PUSH_SCAN
+	EXPECT retry-time-out-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED HAVE_PUSH_SCAN
+	EXPECT retry-time-out-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >0 IF-DEFINED HAVE_PUSH_SCAN
+	EXPECT which-jobs-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+
+	#printer status attributes..
+	EXPECT printer-alert OF-TYPE octetString IN-GROUP printer-attributes-tag
+	EXPECT printer-alert-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-alert
+	EXPECT printer-config-change-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-config-change-time OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >-1
+	EXPECT printer-current-time OF-TYPE datetime IN-GROUP printer-attributes-tag 
+	EXPECT printer-is-accepting-jobs OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-state-change-time OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >-1
+	EXPECT printer-state-change-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT printer-state-message OF-TYPE text IN-GROUP printer-attributes-tag
+	EXPECT printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT printer-up-time OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT printer-uri-supported OF-TYPE uri IN-GROUP printer-attributes-tag SAME-COUNT-AS uri-security-supported WITH-ALL-VALUES "$IPP_URI_SCHEME"
+	EXPECT printer-uuid OF-TYPE uri IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^urn:uuid:[0-9A-Fa-f]{8,8}-[0-9A-Fa-f]{4,4}-[0-9A-Fa-f]{4,4}-[0-9A-Fa-f]{4,4}-[0-9A-Fa-f]{12,12}/"
+	EXPECT queued-job-count OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+	EXPECT xri-security-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+	EXPECT  xri-authentication-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+	EXPECT xri-uri-scheme-supported OF-TYPE uriScheme IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+
+#Additional Values and Semantics...
+	EXPECT ipp-features-supported WITH-VALUE "scan"
+
+}
+
+
+
+#Get-Printer-Attributes test to check the input-sides-supported printer description attribute
+{
+	SKIP-IF-NOT-DEFINED HAVE_DUPLEX_SCANNING_ACCESSORIES 
+
+	NAME "Required Operations and Attributes"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format application/octet-stream
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+	EXPECT input-sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag  
+}
+
+
+
+#Creating a job to later use the get-job-attributes operation to test the required job description attributes and also the get-next-document operation
+{
+	NAME "create-job for IPP Scan Service"
+
+	OPERATION Create-Job
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+
+	STATUS successful-ok
+	STATUS successful-ok-ignored-or-substituted-attributes
+
+	EXPECT job-id
+	EXPECT job-uri
+	EXPECT compression OF-TYPE keyword IN-GROUP job-attributes-tag
+}
+#testing the Required Get-Next-Document-Data operation
+{
+	NAME "Get-Next-Document-Data Operation"
+
+	OPERATION Get-Next-Document-Data
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-busy
+
+	EXPECT compression OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT document-format OF-TYPE mimeMediaType IN-GROUP job-attributes-tag
+	EXPECT document-data-get-interval OF-TYPE integer IN-GROUP job-attributes-tag DEFINE-VALUE GET_INTERVAL
+}
+{
+	SKIP-IF-NOT-DEFINED GET_INTERVAL
+	DELAY $GET_INTERVAL
+
+	NAME "Get-Job-Attributes: Wait for completion"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes job-state
+
+	STATUS successful-ok
+
+        # Repeat while we are not canceled, aborted, or completed...
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE <7 REPEAT-MATCH
+}
+
+
+
+
+# Test required Job Description/Status Attributes
+{
+	NAME "IPP Job Description/Status Attributes required for IPP Scan Service"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job_id
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes all
+
+	STATUS successful-ok
+
+	# Job Status attributes
+	EXPECT date-time-at-completed OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT date-time-at-creation OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT date-time-at-processing OF-TYPE dateTime IN-GROUP job-attributes-tag
+	EXPECT destination-statuses OF-TYPE collection IN-GROUP job-attributes-tag SAME-COUNT-AS destination-uris	
+	EXPECT document-name-supplied OF-TYPE name IN-GROUP job-attributes-tag 
+	EXPECT input-attributes-actual OF-TYPE collection IN-GROUP job-attributes-tag 
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-impressions-completed OF-TYPE integer|no-value IN-GROUP job-attributes-tag COUNT 1
+	EXPECT job-impressions OF-TYPE integer|no-value IN-GROUP job-attributes-tag COUNT 1
+	EXPECT job-originating-user-name OF-TYPE name IN-GROUP job-attributes-tag
+	EXPECT job-originating-user-uri OF-TYPE uri IN-GROUP job-attributes-tag
+	EXPECT job-printer-up-time OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT job-printer-uri OF-TYPE uri IN-GROUP job-attributes-tag WITH-VALUE "$uri"
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag
+	EXPECT job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag
+	EXPECT job-uuid OF-TYPE uri IN-GROUP job-attributes-tag WITH-VALUE "/^urn:uuid:/"
+	EXPECT time-at-completed OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT time-at-creation OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT time-at-processing OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0	
+}
+
+
+#scan job test using destination uri
+
+{
+	SKIP-IF-NOT-DEFINED DESTINATION_URI
+
+	NAME "create-job for testing IPP Scan Service with destination uri "
+
+	OPERATION Create-Job
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+
+	GROUP job-attributes-tag
+	ATTR collection destination-uris {
+		MEMBER uri destination-uri $DESTINATION_URI
+	}
+
+	STATUS successful-ok
+	STATUS successful-ok-ignored-or-substituted-attributes
+
+	EXPECT job-id DEFINE-VALUE JOBID_DESTINATION_URI
+	EXPECT job-uri
+	EXPECT compression OF-TYPE keyword IN-GROUP job-attributes-tag
+}
+{
+	SKIP-IF-NOT-DEFINED JOBID_DESTINATION_URI
+
+	NAME "Get-Next-Document-Data Operation"
+
+	OPERATION Get-Next-Document-Data
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_DESTINATION_URI
+	ATTR name requesting-user-name $user
+	
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-busy
+
+	EXPECT compression OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT document-format OF-TYPE mimeMediaType IN-GROUP job-attributes-tag
+}

--- a/examples/pwg5100.2.test
+++ b/examples/pwg5100.2.test
@@ -1,0 +1,1405 @@
+#Test to confirm presence of output-bin-default and output-bin-supported in get-printer-attributes response (Syntax and Range)
+{
+	NAME "get-printer-attributes: Expect output-bin-default and output-bin-supported"
+	
+	OPERATION Get-Printer-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	
+
+	DISPLAY output-bin-default
+	DISPLAY output-bin-supported
+
+	STATUS successful-ok
+	EXPECT output-bin-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM output-bin-supported
+	EXPECT output-bin-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag 
+	
+	# Job template attributes for specific tests...
+	EXPECT output-bin-supported WITH-VALUE "top" DEFINE-MATCH OPTIONAL_TOP_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "middle" DEFINE-MATCH OPTIONAL_MIDDLE_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "bottom" DEFINE-MATCH OPTIONAL_BOTTOM_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "side" DEFINE-MATCH OPTIONAL_SIDE_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "left" DEFINE-MATCH OPTIONAL_LEFT_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "right" DEFINE-MATCH OPTIONAL_RIGHT_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "center" DEFINE-MATCH OPTIONAL_CENTER_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "rear" DEFINE-MATCH OPTIONAL_REAR_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "face-down" DEFINE-MATCH OPTIONAL_FACEDOWN_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "face-up" DEFINE-MATCH OPTIONAL_FACEUP_OUTPUTBIN 
+	EXPECT output-bin-supported WITH-VALUE "large-capacity" DEFINE-MATCH OPTIONAL_LARGECAPACITY_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "my-mailbox" DEFINE-MATCH OPTIONAL_MYMAILBOX_OUTPUTBIN
+
+	EXPECT output-bin-supported WITH-VALUE "/^stacker-[1-9][0-9]*$$/" DEFINE-MATCH OPTIONAL_STACKERN_OUTPUTBIN 
+	EXPECT output-bin-supported WITH-VALUE "stacker-1" IF-DEFINED OPTIONAL_STACKERN_OUTPUTBIN 
+	EXPECT output-bin-supported WITH-VALUE "stacker-1" DEFINE-MATCH OPTIONAL_STACKER1_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "stacker-2" DEFINE-MATCH OPTIONAL_STACKER2_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "/^mailbox-[1-9][0-9]*$$/" DEFINE-MATCH OPTIONAL_MAILBOXN_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "mailbox-1" IF-DEFINED OPTIONAL_MAILBOXN_OUTPUTBIN 
+	EXPECT output-bin-supported WITH-VALUE "mailbox-1" DEFINE-MATCH OPTIONAL_MAILBOX1_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "mailbox-2" DEFINE-MATCH OPTIONAL_MAILBOX2_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "tray-1" DEFINE-MATCH OPTIONAL_TRAY1_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "tray-2" DEFINE-MATCH OPTIONAL_TRAY2_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "tray-3" DEFINE-MATCH OPTIONAL_TRAY3_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "tray-4" DEFINE-MATCH OPTIONAL_TRAY4_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "tray-5" DEFINE-MATCH OPTIONAL_TRAY5_OUTPUTBIN
+	EXPECT output-bin-supported WITH-VALUE "tray-6" DEFINE-MATCH OPTIONAL_TRAY6_OUTPUTBIN
+
+}
+
+
+#Print-Job request with output-bin top
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TOP_OUTPUTBIN
+
+	NAME "Print-Job with top output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "top"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with top output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TOP_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "top"
+}
+
+#Print-Job request with output-bin middle
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MIDDLE_OUTPUTBIN
+
+	NAME "Print-Job with middle output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "middle"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+ 
+# Test Get-Job-Attributes operation (specific to middle output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MIDDLE_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "middle"
+}
+
+
+#Print-Job request with output-bin bottom
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_BOTTOM_OUTPUTBIN
+
+	NAME "Print-Job with bottom output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "bottom"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to bottom output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_BOTTOM_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "bottom"
+}
+
+
+#Print-Job request with output-bin side
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_SIDE_OUTPUTBIN
+
+	NAME "Print-Job with side output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "side"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to side output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_SIDE_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "side"
+}
+
+
+#Print-Job request with output-bin left
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_LEFT_OUTPUTBIN
+
+	NAME "Print-Job with left output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "left"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to left output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_LEFT_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "left"
+}
+
+
+#Print-Job request with output-bin right
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_RIGHT_OUTPUTBIN
+
+	NAME "Print-Job with right output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "right"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to right output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_RIGHT_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "right"
+}
+
+
+#Print-Job request with output-bin center
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_CENTER_OUTPUTBIN
+
+	NAME "Print-Job with center output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "center"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to center output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_CENTER_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "center"
+}
+
+
+
+#Print-Job request with output-bin rear
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_REAR_OUTPUTBIN
+
+	NAME "Print-Job with rear output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "rear"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to rear output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_REAR_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "rear"
+}
+
+
+#Print-Job request with output-bin face-down
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_FACEDOWN_OUTPUTBIN
+
+	NAME "Print-Job with face-down output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "face-down"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to face-down output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_FACEDOWN_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "face-down" 
+}
+
+#Print-Job request with output-bin face-up
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_FACEUP_OUTPUTBIN
+
+	NAME "Print-Job with face-up output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "face-up"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to face-up output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_FACEUP_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "face-up"
+}
+
+
+
+#Print-Job request with output-bin large-Capacity
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_LARGECAPACITY_OUTPUTBIN
+
+	NAME "Print-Job with large-capacity output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "large-capacity"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to large-capacity output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_LARGECAPACITY_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "large-capacity"
+}
+
+
+#Print-Job request with output-bin my-mailbox
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MYMAILBOX_OUTPUTBIN
+
+	NAME "Print-Job with my-mailbox output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "my-mailbox"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to my-mailbox output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MYMAILBOX_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT ?output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "my-mailbox"
+}
+
+#Print-Job request with output-bin stacker-1
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_STACKER1_OUTPUTBIN
+
+	NAME "Print-Job with stacker-1 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "stacker-1"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with stacker-1 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_STACKER1_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "stacker-1"
+}
+
+#Print-Job request with output-bin stacker-2
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_STACKER2_OUTPUTBIN
+
+	NAME "Print-Job with stacker-2 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "stacker-2"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with stacker-2 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_STACKER2_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "stacker-2"
+}
+
+
+
+#Print-Job request with output-bin mailbox-1
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MAILBOX1_OUTPUTBIN
+
+	NAME "Print-Job with mailbox-1 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "mailbox-1"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with mailbox-1 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MAILBOX1_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "mailbox-1"
+}
+
+#Print-Job request with output-bin mailbox-2
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MAILBOX2_OUTPUTBIN
+
+	NAME "Print-Job with mailbox-2 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "mailbox-2"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with mailbox-2 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_MAILBOX2_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "mailbox-2"
+}
+
+#Print-Job request with output-bin tray-1
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY1_OUTPUTBIN
+
+	NAME "Print-Job with tray-1 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "tray-1"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with tray-1 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY1_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "tray-1"
+}
+
+#Print-Job request with output-bin tray-2
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY2_OUTPUTBIN
+
+	NAME "Print-Job with tray-2 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "tray-2"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with tray-2 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY2_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "tray-2"
+}
+
+
+#Print-Job request with output-bin tray-3
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY3_OUTPUTBIN
+
+	NAME "Print-Job with tray-3 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "tray-3"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with tray-3 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY3_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "tray-3"
+}
+#Print-Job request with output-bin tray-4
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY4_OUTPUTBIN
+
+	NAME "Print-Job with tray-4 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "tray-4"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with tray-4 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY4_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "tray-4"
+}
+
+#Print-Job request with output-bin tray-5
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY5_OUTPUTBIN
+
+	NAME "Print-Job with tray-5 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "tray-5"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with tray-5 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY5_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "tray-5"
+}
+
+#Print-Job request with output-bin tray-6
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY6_OUTPUTBIN
+
+	NAME "Print-Job with tray-6 output-bin"
+	
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR keyword output-bin "tray-6"
+	
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Job-Attributes operation (specific to job printed with tray-6 output-bin)
+{
+	SKIP-IF-DEFINED NOPRINT
+	SKIP-IF-NOT-DEFINED OPTIONAL_TRAY6_OUTPUTBIN
+
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	
+	OPERATION Get-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	DISPLAY output-bin
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT output-bin OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "tray-6"
+}

--- a/examples/pwg5100.8.test
+++ b/examples/pwg5100.8.test
@@ -1,0 +1,257 @@
+# Test file to test the -actual attribute extension (pwg5100.8)
+
+
+# Test Print-Job operation
+{
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state WITH-VALUE 7,8,9 DEFINE-MATCH PRINT_JOB_COMPLETED
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Get-Jobs operation for not-completed jobs to check the '-actual' attributes
+{
+	SKIP-IF-DEFINED PRINT_JOB_COMPLETED
+
+	NAME "RFC 8011 section 4.2.6: Get-Jobs Operation (which-jobs=not-completed, requested-attributes)"
+	OPERATION Get-Jobs
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes all
+	ATTR keyword which-jobs not-completed
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	
+	#tests on -actual attributes
+	EXPECT ?copies-actual OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT ?cover-back-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?cover-front-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?document-overrides-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag  
+	EXPECT ?finishings-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag
+	EXPECT ?finishings-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?force-front-side-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag  
+	EXPECT ?imposition-template-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?insert-sheet-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-account-id-actual OF-TYPE name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-accounting-sheets-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-accounting-user-id-actual OF-TYPE name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-error-sheet-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-hold-until-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?job-message-to-operator-actual OF-TYPE text|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-priority-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0,<101
+	EXPECT ?job-sheets-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-sheets-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-sheet-message-actual OF-TYPE text|unknown IN-GROUP job-attributes-tag
+	EXPECT ?media-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?media-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?media-input-tray-check-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?multiple-document-handling-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
+	EXPECT ?number-up-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT ?orientation-requested-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag WITH-VALUE 3,4,5,6
+	EXPECT ?output-bin-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?page-delivery-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(same-order-face-up|same-order-face-down|reverse-order-face-up|reverse-order-face-down|system-specified)$$/"
+	EXPECT ?page-order-received-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(1-to-n-order|n-to-1-order)$$/"
+	EXPECT ?page-ranges-actual OF-TYPE rangeOfInteger|unknown IN-GROUP job-attributes-tag
+	EXPECT ?pages-per-subset-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?print-color-mode-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
+	EXPECT ?print-content-optimize-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|graphic|photo|text|text-and-graphic)$/"
+	EXPECT ?print-rendering-intent-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
+	EXPECT ?presentation-direction-number-up-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(toright-tobottom|tobottom-toright|toleft-tobottom|tobottom-toleft|toright-totop|totop-toright|toleft-totop|totop-toleft)$$/" 
+	EXPECT ?print-quality-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag WITH-VALUE 3,4,5
+	EXPECT ?printer-resolution-actual OF-TYPE resolution|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?separator-sheets-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?sheet-collate-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(uncollated|collated)$$/"
+	EXPECT ?sides-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
+	EXPECT ?x-image-position-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(none|center|left|right)$$/"
+	EXPECT ?x-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?x-side1-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?x-side2-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag	
+	EXPECT ?y-image-position-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(none|center|left|right)$$/"
+	EXPECT ?y-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?y-side1-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?y-side2-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+}
+
+
+
+# Wait for job to complete...
+{
+	SKIP-IF-NOT-DEFINED job-id
+
+	NAME "Get-Job-Attributes Until Job Complete"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+	DISPLAY job-state
+}
+
+# Test Get-Jobs operation
+{
+	NAME "RFC 8011 section 4.2.6: Get-Jobs Operation (which-jobs, requested-attributes)"
+	OPERATION Get-Jobs
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes all
+	ATTR keyword which-jobs completed
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	
+	#tests on -actual attributes
+	EXPECT ?copies-actual OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT ?cover-back-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?cover-front-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?document-overrides-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag  
+	EXPECT ?finishings-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag
+	EXPECT ?finishings-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?force-front-side-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag  
+	EXPECT ?imposition-template-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?insert-sheet-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-account-id-actual OF-TYPE name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-accounting-sheets-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-accounting-user-id-actual OF-TYPE name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-error-sheet-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-hold-until-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?job-message-to-operator-actual OF-TYPE text|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-priority-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0,<101
+	EXPECT ?job-sheets-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-sheets-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-sheet-message-actual OF-TYPE text|unknown IN-GROUP job-attributes-tag
+	EXPECT ?media-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?media-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?media-input-tray-check-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?multiple-document-handling-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
+	EXPECT ?number-up-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT ?orientation-requested-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag WITH-VALUE 3,4,5,6
+	EXPECT ?output-bin-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?page-delivery-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(same-order-face-up|same-order-face-down|reverse-order-face-up|reverse-order-face-down|system-specified)$$/"
+	EXPECT ?page-order-received-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(1-to-n-order|n-to-1-order)$$/"
+	EXPECT ?page-ranges-actual OF-TYPE rangeOfInteger|unknown IN-GROUP job-attributes-tag
+	EXPECT ?pages-per-subset-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?print-color-mode-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
+	EXPECT ?print-content-optimize-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|graphic|photo|text|text-and-graphic)$/"
+	EXPECT ?print-rendering-intent-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
+	EXPECT ?presentation-direction-number-up-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(toright-tobottom|tobottom-toright|toleft-tobottom|tobottom-toleft|toright-totop|totop-toright|toleft-totop|totop-toleft)$$/" 
+	EXPECT ?print-quality-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag WITH-VALUE 3,4,5
+	EXPECT ?printer-resolution-actual OF-TYPE resolution|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?separator-sheets-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?sheet-collate-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(uncollated|collated)$$/"
+	EXPECT ?sides-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
+	EXPECT ?x-image-position-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(none|center|left|right)$$/"
+	EXPECT ?x-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?x-side1-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?x-side2-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag	
+	EXPECT ?y-image-position-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(none|center|left|right)$$/"
+	EXPECT ?y-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?y-side1-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?y-side2-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+}
+
+
+
+
+# Test Get-Job-Attributes operation
+{
+	NAME "RFC 8011 section 4.3.4: Get-Job-Attributes Operation"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "$IPP_URI_SCHEME"
+	
+	#tests on -actual attributes
+	EXPECT ?copies-actual OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT ?cover-back-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?cover-front-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?document-overrides-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag  
+	EXPECT ?finishings-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag
+	EXPECT ?finishings-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?force-front-side-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag  
+	EXPECT ?imposition-template-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?insert-sheet-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-account-id-actual OF-TYPE name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-accounting-sheets-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-accounting-user-id-actual OF-TYPE name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-error-sheet-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-hold-until-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?job-message-to-operator-actual OF-TYPE text|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-priority-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >0,<101
+	EXPECT ?job-sheets-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-sheets-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?job-sheet-message-actual OF-TYPE text|unknown IN-GROUP job-attributes-tag
+	EXPECT ?media-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?media-col-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?media-input-tray-check-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?multiple-document-handling-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(single-document|separate-documents-uncollated-copies|separate-documents-collated-copies|single-document-new-sheet)$$/"
+	EXPECT ?number-up-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag WITH-VALUE >0
+	EXPECT ?orientation-requested-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag WITH-VALUE 3,4,5,6
+	EXPECT ?output-bin-actual OF-TYPE keyword|name|unknown IN-GROUP job-attributes-tag
+	EXPECT ?page-delivery-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(same-order-face-up|same-order-face-down|reverse-order-face-up|reverse-order-face-down|system-specified)$$/"
+	EXPECT ?page-order-received-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(1-to-n-order|n-to-1-order)$$/"
+	EXPECT ?page-ranges-actual OF-TYPE rangeOfInteger|unknown IN-GROUP job-attributes-tag
+	EXPECT ?pages-per-subset-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?print-color-mode-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
+	EXPECT ?print-content-optimize-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|graphic|photo|text|text-and-graphic)$/"
+	EXPECT ?print-rendering-intent-actual OF-TYPE keyword IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
+	EXPECT ?presentation-direction-number-up-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(toright-tobottom|tobottom-toright|toleft-tobottom|tobottom-toleft|toright-totop|totop-toright|toleft-totop|totop-toleft)$$/" 
+	EXPECT ?print-quality-actual OF-TYPE enum|unknown IN-GROUP job-attributes-tag WITH-VALUE 3,4,5
+	EXPECT ?printer-resolution-actual OF-TYPE resolution|unknown IN-GROUP job-attributes-tag 
+	EXPECT ?separator-sheets-actual OF-TYPE collection|unknown IN-GROUP job-attributes-tag
+	EXPECT ?sheet-collate-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(uncollated|collated)$$/"
+	EXPECT ?sides-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
+	EXPECT ?x-image-position-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(none|center|left|right)$$/"
+	EXPECT ?x-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?x-side1-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?x-side2-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag	
+	EXPECT ?y-image-position-actual OF-TYPE keyword|unknown IN-GROUP job-attributes-tag WITH-VALUE "/^(none|center|left|right)$$/"
+	EXPECT ?y-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?y-side1-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+	EXPECT ?y-side2-image-shift-actual OF-TYPE integer|unknown IN-GROUP job-attributes-tag
+}

--- a/examples/rfc3380.test
+++ b/examples/rfc3380.test
@@ -1,0 +1,651 @@
+#This test files contains various tests related to concepts in RFC 3380-Job and Printer Set Operations
+
+#Checking for supported operations.
+{
+	NAME "Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	STATUS successful-ok
+
+	# Operations
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag
+	EXPECT operations-supported WITH-VALUE 0x0013 DEFINE-MATCH SET_PRINTER_ATTRIBUTES_SUPPORTED #Set-Printer-Attributes
+	EXPECT operations-supported WITH-VALUE 0x0014 DEFINE-MATCH SET_JOB_ATTRIBUTES_SUPPORTED # Set-Job-Attributes
+	EXPECT operations-supported WITH-VALUE 0x0015 DEFINE-MATCH GET_PRINTER_SUPPORTED_VALUES_SUPPORTED # Get-Printer-Supported-Values	
+	EXPECT operations-supported WITH-VALUE 0x0010 DEFINE-MATCH PAUSE_PRINTER_SUPPORTED # Pause-Printer
+	EXPECT operations-supported WITH-VALUE 0x0011 DEFINE-MATCH RESUME_PRINTER_SUPPORTED # Resume-Printer
+	EXPECT operations-supported WITH-VALUE 0x000c DEFINE-MATCH HOLD_JOB_SUPPORTED # Hold-Job
+	EXPECT operations-supported WITH-VALUE 0x000d DEFINE-MATCH RELEASE_JOB_SUPPORTED # Release-Job
+	EXPECT operations-supported WITH-VALUE 0x0008 DEFINE-MATCH CANCEL_JOB_SUPPORTED #Cancel-Job 
+
+	#printer description attributes
+	EXPECT ?printer-message-from-operator OF-TYPE text IN-GROUP printer-attributes-tag DEFINE-MATCH PRINTER_MESSAGE_FROM_OPERATOR_SUPPORTED
+	EXPECT printer-settable-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+	EXPECT job-settable-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+	EXPECT ?document-format-varying-attributes OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT ?printer-message-date-time OF-TYPE dateTime IN-GROUP printer-attributes-tag
+	EXPECT printer-xri-supported OF-TYPE collection IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+	EXPECT xri-security-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+	EXPECT  xri-authentication-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+	EXPECT xri-uri-scheme-supported OF-TYPE uriScheme IN-GROUP printer-attributes-tag IF-DEFINED SETTING_PRINTER_XRI_SUPPORTED
+	
+	
+
+	#defining variables for specific tests
+	EXPECT copies-supported WITH-VALUE >1 DEFINE-MATCH OPTIONAL_COPIES
+	EXPECT printer-settable-attributes-supported WITH-VALUE "none" DEFINE-MATCH PRINTER_ATTRIBUTES_NOT_SETTABLE
+	EXPECT printer-message-time OF-TYPE integer IN-GROUP printer-attributes-tag DEFINE-MATCH PRINTER_MESSAGE_TIME_SUPPORTED
+	EXPECT printer-current-time OF-TYPE datetime IN-GROUP printer-attributes-tag DEFINE-MATCH PRINTER_CURRENT_TIME_SUPPORTED
+}
+
+
+#test to check if the Get-Printer-Supported-Value operation is supported when the Set-Printer-Attribute operation is supported and some of the printer attributes are settable.
+{
+	SKIP-IF-DEFINED PRINTER_ATTRIBUTES_NOT_SETTABLE
+	SKIP-IF-NOT-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+
+	NAME "Get-Printer-Attributes to confirm conditional support for Get-Printer-Values-Supported"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	STATUS successful-ok
+
+	EXPECT operations-supported WITH-VALUE 0x0015 
+} 
+
+#test to confirm support for printer-message-date-time attribute if printer-message-time and printer-current-time attribute are defined.
+{
+	SKIP-IF-NOT-DEFINED PRINTER_MESSAGE_TIME_SUPPORTED
+	SKIP-IF-NOT-DEFINED PRINTER_CURRENT_TIME_SUPPORTED
+
+	NAME "Get-Printer-Attributes to confirm conditional support for printer-message-date-time attribute"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	STATUS successful-ok
+
+	EXPECT printer-message-date-time OF-TYPE datetime IN-GROUP printer-attributes-tag
+}
+
+
+
+#Print-job. To check if job-message-from-operator is defined. Will be queried using the Get-Job-Attributes operation
+{
+
+	NAME "Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_GETJOBATTRIBUTES
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+	
+}
+
+#Check the job-message-from-operator is supported or not
+{
+	SKIP-IF-NOT-DEFINED JOBID_GETJOBATTRIBUTES
+
+	NAME "Get-Job-Attributes Operation to check support for job-message-from-operator"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_GETJOBATTRIBUTES
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes job-message-from-operator
+
+	STATUS successful-ok
+	
+	EXPECT job-message-from-operator IN-GROUP job-attributes-tag DEFINE-MATCH JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+}
+
+
+
+
+#test current copies-default value. Will be modified using the Set-Printer-Attributes operation in the following test.
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_COPIES
+	SKIP-IF-NOT-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+
+	NAME "Get-Printer-Attributes to check copies-default"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes copies-default
+	
+	STATUS successful-ok
+
+	DISPLAY copies-default
+
+	EXPECT copies-default OF-TYPE integer IN-GROUP printer-attributes-tag
+}
+
+
+#Test for Set-Printer-Attributes operation (setting the default number of copies printed to 2)
+{
+	SKIP-IF-NOT-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+	SKIP-IF-NOT-DEFINED OPTIONAL_COPIES
+
+	NAME "Section 4.1: Set-Printer-Attributes operation"
+	OPERATION Set-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	GROUP printer-attributes-tag
+	ATTR integer copies-default 2
+
+	STATUS successful-ok
+	STATUS client-error-attributes-not-settable
+	STATUS client-error-conflicting-attributes
+	STATUS client-error-request-entity-too-large
+	STATUS client-error-attributes-or-values-not-supported
+
+}
+
+#test current copies-default value after modifying using the Set-Printer-Attributes operation in the following test. Expected value is 2.
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_COPIES
+	SKIP-IF-NOT-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+
+	NAME "Get-Printer-Attributes to check copies-default"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes copies-default
+	
+	STATUS successful-ok
+
+	DISPLAY copies-default
+
+	EXPECT copies-default OF-TYPE integer IN-GROUP printer-attributes-tag
+}
+
+
+#test setting printer-message-from-operator printer description attribute if it is supported
+{
+	SKIP-IF-NOT-DEFINED PRINTER_MESSAGE_FROM_OPERATOR_SUPPORTED
+	SKIP-IF-NOT-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+
+	NAME "Section 4.1: Set-Printer-Attributes operation"
+	OPERATION Set-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	GROUP printer-attributes-tag
+	ATTR text printer-message-from-operator "Setting the printer-message-from-operator"
+
+	STATUS successful-ok
+
+}
+
+
+# Test Print-Job operation with copies = 1. Copies attribute to be changed using Set-Job-Attribute test in the following operation.
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_COPIES
+	SKIP-IF-NOT-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+
+	NAME "Print-Job Operation With copies = 1"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	Group job-attributes-tag
+	ATTR integer copies 1
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_SET_JOB_ATTRIBUTES
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state WITH-VALUE 7,8,9 DEFINE-MATCH PRINT_JOB_COMPLETED_SET_JOB_ATTRIBUTES
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#Test the Set-Job-Attributes operation
+{
+	SKIP-IF-NOT-DEFINED JOBID_SET_JOB_ATTRIBUTES
+	SKIP-IF-NOT-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+	SKIP-IF-DEFINED PRINT_JOB_COMPLETED_SET_JOB_ATTRIBUTES
+
+
+	NAME "RFC 3380 section 4.2: Set-Job-Attributes Operation"
+	
+	OPERATION Set-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_SET_JOB_ATTRIBUTES
+	ATTR name requesting-user-name $user
+
+	Group job-attributes-tag
+	ATTR integer copies 2 
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+	STATUS client-error-request-entity-too-large
+	STATUS client-error-attributes-or-values-not-supported
+	STATUS client-error-attributes-not-settable
+	STATUS client-error-attributes-or-values-not-supported
+	STATUS client-error-conflicting-attributes
+
+}
+
+#test setting job-message-from-operator job description attribute if it is supported
+{
+	#SKIP-IF-NOT-DEFINED JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+	SKIP-IF-NOT-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_SET_JOB_ATTRIBUTES
+
+	NAME "Section 4.1: Set-Job-Attributes operation"
+	OPERATION Set-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_SET_JOB_ATTRIBUTES
+	ATTR name requesting-user-name $user
+
+	Group job-attributes-tag
+	ATTR text job-message-from-operator "Setting the job-message-from-operator"
+
+	STATUS successful-ok
+
+}
+
+#Check the copies of the print-job using the get-job-attributes test
+{
+	SKIP-IF-NOT-DEFINED JOBID_SET_JOB_ATTRIBUTES
+	SKIP-IF-NOT-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+
+	NAME "Get-Job-Attributes Operation to check number of copies "
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_SET_JOB_ATTRIBUTES
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes copies
+
+	STATUS successful-ok
+	
+	EXPECT copies OF-TYPE integer IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE 2
+}
+
+
+
+
+#test the detete-attribute value tag. Will create a job with the copies attribute and then delete the copies attribute
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_COPIES
+	SKIP-IF-NOT-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+
+	NAME "Print-Job Operation With copies = 1"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	Group job-attributes-tag
+	ATTR integer copies 1
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_DELETE_JOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state WITH-VALUE 7,8,9 DEFINE-MATCH PRINT_JOB_COMPLETED_DELETE_JOB
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+#Test the Set-Job-Attributes operation
+{
+	SKIP-IF-NOT-DEFINED JOBID_DELETE_JOB
+	SKIP-IF-NOT-DEFINED SET_JOB_ATTRIBUTES_SUPPORTED
+	SKIP-IF-DEFINED PRINT_JOB_COMPLETED_DELETE_JOB
+
+
+	NAME "Set-Job-Attributes Operation -Deleting a job attribute"
+	
+	OPERATION Set-Job-Attributes
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_DELETE_JOB
+	ATTR name requesting-user-name $user
+
+	Group job-attributes-tag
+	ATTR delete-attribute copies
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+	STATUS client-error-request-entity-too-large
+	STATUS client-error-attributes-or-values-not-supported
+	STATUS client-error-attributes-not-settable
+	STATUS client-error-attributes-or-values-not-supported
+	STATUS client-error-conflicting-attributes
+
+}
+
+
+#Below tests invlove using the Get-Printer-Supported-Values operation to check if an attribute of form xxx-supported specified by the user has an 'admin-define' out-of-band attribute value. If it does then in that case we use the Set-Printer-Attributes to set a value specified by the user using the name attribute syntax
+
+#Test for the Get-Printer-Supported-Values Operation
+{
+	SKIP-IF-NOT-DEFINED GET_PRINTER_SUPPORTED_VALUES_SUPPORTED
+	SKIP-IF-NOT-DEFINED SET_ATTR_NAME
+
+	NAME "RFC 3380 Section 4.3: Get-Printer-Supported-Values operation"
+	OPERATION Get-Printer-Supported-Values
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	EXPECT $SET_ATTR_NAME WITH-VALUE "admin-define" DEFINE-MATCH ADMIN_DEFINE_SUPPORTED
+
+}
+{
+	SKIP-IF-NOT-DEFINED ADMIN_DEFINE_SUPPORTED
+	SKIP-IF-NOT-DEFINED SET_ATTR_VALUE
+	SKIP-IF-NOT-DEFINED SET_PRINTER_ATTRIBUTES_SUPPORTED
+
+	NAME "Section 4.1: Set-Printer-Attributes operation"
+	OPERATION Set-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	GROUP printer-attributes-tag
+	ATTR name $SET_ATTR_NAME $SET_ATTR_VALUE
+
+	STATUS successful-ok
+	STATUS client-error-attributes-not-settable
+	STATUS client-error-conflicting-attributes
+	STATUS client-error-request-entity-too-large
+	STATUS client-error-attributes-or-values-not-supported
+
+}
+
+
+#Test for checking the support of printer-message-from-operator in the pause and resume printer operations provided the printer-message-from-operator printer description attribute is defined
+
+#test Pause-Printer operation followed by resume printer operation
+{
+	SKIP-IF-NOT-DEFINED PAUSE_PRINTER_SUPPORTED
+	SKIP-IF-NOT-DEFINED PRINTER_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	NAME "Pause-Printer Operation with printer-message-from-operator operation attribute"
+	
+	Operation Pause-Printer
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri                                                             
+	ATTR name requesting-user-name $user
+	ATTR text printer-message-from-operator "pausing the printer"
+
+	STATUS successful-ok
+}
+#Resume-Printer operation
+{
+	SKIP-IF-NOT-DEFINED RESUME_PRINTER_SUPPORTED
+	SKIP-IF-NOT-DEFINED PRINTER_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	Name "Resume-Printer with printer-message-from-operator operation attribute"
+
+	Operation Resume-Printer
+
+	Group operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR text printer-message-from-operator "The printer is curently working"
+
+	Status successful-ok
+} 
+{
+	SKIP-IF-NOT-DEFINED PRINTER_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	NAME "Get-Printer-Attributes to check printer-message-from-operator"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR keyword requested-attributes printer-message-from-operator
+	
+	STATUS successful-ok
+
+	DISPLAY printer-message-from-operator
+
+	EXPECT printer-message-from-operator OF-TYPE text IN-GROUP printer-attributes-tag WITH-VALUE "The printer is curently working"
+}
+
+#Test if job-message-from-operator operation attributes works with Cancel-Job, Hold-Job and Release-Job operations. These tests are provided that the job-message-from-operator job description attribute is supported.
+
+#print-job operation. Job to be cancelled using cancel job operation along with job-message-from-operator
+{
+	SKIP-IF-NOT-DEFINED CANCEL_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	NAME "Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_CANCEL_JOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Cancel-Job operation
+{
+	SKIP-IF-NOT-DEFINED JOBID_CANCEL_JOB
+	SKIP-IF-NOT-DEFINED CANCEL_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	NAME "Cancel-Job Operation with job-message-from-operator"
+	OPERATION Cancel-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_CANCEL_JOB
+	ATTR name requesting-user-name $user
+	ATTR text job-message-from-operator "This job is being cancelled"
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+#print-job.Job to be held and released using Hold-Job and Release-Job operation along with job-message-from-operator
+{
+	SKIP-IF-NOT-DEFINED RELEASE_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED HOLD_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	NAME "Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_HOLD_JOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+# Test Hold-Job operation with job-message-from-operator operation attribute
+{
+	SKIP-IF-NOT-DEFINED HOLD_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_HOLD_JOB
+	SKIP-IF-NOT-DEFINED JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+
+	Name "Hold-Job operation with job-message-from-operator operation attribute"
+
+	Operation Hold-Job
+
+	Group operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_HOLD_JOB
+	ATTR name requesting-user-name $user
+	ATTR text job-message-from-operator "The job has been held"
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+#Release-Job Operation with job-message-from-operator operation attribute
+{
+	SKIP-IF-NOT-DEFINED RELEASE_JOB_SUPPORTED		
+	SKIP-IF-NOT-DEFINED JOBID_HOLD_JOB
+	SKIP-IF-NOT-DEFINED JOB_MESSAGE_FROM_OPERATOR_SUPPORTED
+
+	NAME "Release-Job with job-message-from-operator operation attribute"
+	OPERATION Release-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_HOLD_JOB
+	ATTR name requesting-user-name $user
+	ATTR text job-message-from-operator "The job has been released"
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+	
+
+

--- a/examples/rfc3998.test
+++ b/examples/rfc3998.test
@@ -1,0 +1,964 @@
+#This test file is developed for RFC3998:IPP Job and Printer Administrative Operations
+
+#Tests the Optional IPP operations and the Conformance Requirement Dependencies for Operations
+{
+	NAME "Section 3: Optional IPP Operations"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	DISPLAY printer-state-reasons
+
+	# Operations
+	EXPECT ?operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag
+	EXPECT ?operations-supported WITH-VALUE 0x22 DEFINE-MATCH ENABLE_PRINTER_SUPPORTED # Enable-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x23 DEFINE-MATCH DISABLE_PRINTER_SUPPORTED # Disable-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x24 DEFINE-MATCH PAUSE_PRINTER_AFTER_CURRENT_JOB_SUPPORTED # Pause-Printer-After-Current-Job
+	EXPECT ?operations-supported WITH-VALUE 0x25 DEFINE-MATCH HOLD_NEW_JOBS_SUPPORTED # Hold-New-Jobs
+	EXPECT ?operations-supported WITH-VALUE 0x26 DEFINE-MATCH RELEASE_HELD_NEW_JOBS_SUPPORTED # Release-Held-New-Jobs
+	EXPECT ?operations-supported WITH-VALUE 0x27 DEFINE-MATCH DEACTIVATE_PRINTER_SUPPORTED # Deactivate-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x28 DEFINE-MATCH ACTIVATE_PRINTER_SUPPORTED # Activate-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x29 DEFINE-MATCH RESTART_PRINTER_SUPPORTED # Restart-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x2A DEFINE-MATCH SHUTDOWN_PRINTER_SUPPORTED # Shutdown-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x2B DEFINE-MATCH STARTUP_PRINTER_SUPPORTED # Startup-Printer
+	EXPECT ?operations-supported WITH-VALUE 0x2C DEFINE-MATCH REPROCESS_JOB_SUPPORTED # Reprocess-Job
+	EXPECT ?operations-supported WITH-VALUE 0x2D DEFINE-MATCH CANCEL_CURRENT_JOB_SUPPORTED # Cancel-Current-Job
+	EXPECT ?operations-supported WITH-VALUE 0x2E DEFINE-MATCH SUSPEND_CURRENT_JOB_SUPPORTED # Suspend-Current-Job
+	EXPECT ?operations-supported WITH-VALUE 0x2F DEFINE-MATCH RESUME_JOB_SUPPORTED # Resume-Job
+	EXPECT ?operations-supported WITH-VALUE 0x30 DEFINE-MATCH PROMOTE_JOB_SUPPORTED # Promote-Job
+	EXPECT ?operations-supported WITH-VALUE 0x31 DEFINE-MATCH SCHEDULE_JOB_AFTER_SUPPORTED # Schedule-Job-After
+	EXPECT operations-supported WITH-VALUE 0x0010 DEFINE-MATCH PAUSE_PRINTER_SUPPORTED # Pause-Printer
+	EXPECT operations-supported WITH-VALUE 0x0011 DEFINE-MATCH RESUME_PRINTER_SUPPORTED # Resume-Printer
+
+	#conformance requirement dependencies for operations
+	EXPECT operations-supported WITH-VALUE 0x22 IF-DEFINED DISABLE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0X23 IF-DEFINED ENABLE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x0010 IF-DEFINED RESUME_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x0011 IF-DEFINED PAUSE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0X0011 IF-DEFINED PAUSE_PRINTER_AFTER_CURRENT_JOB_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x25 IF-DEFINED RELEASE_HELD_NEW_JOBS_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x26 IF-DEFINED HOLD_NEW_JOBS_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x28 IF-DEFINED DEACTIVATE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x23 IF-DEFINED DEACTIVATE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x24 IF-DEFINED DEACTIVATE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x27 IF-DEFINED ACTIVATE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x0011 IF-DEFINED ACTIVATE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x22 IF-DEFINED ACTIVATE_PRINTER_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x2F IF-DEFINED SUSPEND_CURRENT_JOB_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x2E IF-DEFINED RESUME_JOB_SUPPORTED
+	EXPECT operations-supported WITH-VALUE 0x31 IF-DEFINED PROMOTE_JOB_SUPPORTED
+
+
+	#testing new printer description attributes
+	EXPECT subordinate-printers-supported OF-TYPE uri IN-GROUP printer-attributes-tag IF-DEFINED SUBORDINATE_PRINTERS_SUPPORTED_NONLEAF_PRINTER
+	EXPECT parent-printers-supported OF-TYPE uri IN-GROUP printer-attributes-tag IF-DEFINED SUBORDINATE_PRINTERS_SUPPORTED_LEAF_SUBORDINATE_PRINTER
+
+}
+
+#test Disable-Printer operation
+{
+	SKIP-IF-NOT-DEFINED DISABLE_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.1.1: Disable-Printer Operation"
+	OPERATION Disable-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+# Test Print-Job operation after disabling printer. Printer is not supposed to accept any job-creation operation after disabling.
+{
+	SKIP-IF-NOT-DEFINED DISABLE_PRINTER_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS server-error-not-accepting-jobs
+}
+
+# Test Validate-Job operation after disabling printer. Printer accepts this operation.
+{
+	SKIP-IF-NOT-DEFINED DISABLE_PRINTER_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.3: Validate-Job Operation"
+	OPERATION Validate-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+
+	STATUS successful-ok
+}
+
+#test the value of the attribute printer-is-accepting-jobs
+{
+	SKIP-IF-NOT-DEFINED DISABLE_PRINTER_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.5: Get-Printer-Attributes Operation"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR keyword requested-attributes "printer-is-accepting-jobs"
+
+	STATUS successful-ok
+
+	EXPECT printer-is-accepting-jobs WITH-VALUE false
+}
+
+#test for Enable-Printer
+{
+	SKIP-IF-NOT-DEFINED ENABLE_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.1.2: Enable-Printer Operation"
+	OPERATION Enable-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+#test the value of the attribute printer-is-accepting-jobs
+{
+	SKIP-IF-NOT-DEFINED ENABLE_PRINTER_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.5: Get-Printer-Attributes Operation"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR keyword requested-attributes "printer-is-accepting-jobs"
+
+	STATUS successful-ok
+
+	EXPECT printer-is-accepting-jobs WITH-VALUE true
+}
+
+# Test Print-Job operation
+{
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#test for Pause-Printer-After-Current-Job operation
+{
+	SKIP-IF-NOT-DEFINED PAUSE_PRINTER_AFTER_CURRENT_JOB_SUPPORTED
+
+	NAME "RFC 3998 section 3.2.1: Pause-Printer-After-Current-Job Operation"
+	OPERATION Pause-Printer-After-Current-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR integer job-id $job-id
+
+	STATUS successful-ok
+}
+
+{
+	SKIP-IF-NOT-DEFINED PAUSE_PRINTER_AFTER_CURRENT_JOB_SUPPORTED
+
+	NAME "Get-Printer-Attributes Operation to check paused value of printer-state-reasons"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR keyword requested-attributes "printer-state-reasons"
+
+	STATUS successful-ok
+
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "paused"
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "moving-to-paused"
+}
+
+
+#Resuming the printer again
+{
+	NAME "Resume-Printer"
+
+	OPERATION Resume-Printer
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+}
+
+
+#test Pause-Printer operation followed by test for "paused" value of printer-state-reasons
+{
+	SKIP-IF-NOT-DEFINED PAUSE_PRINTER_SUPPORTED
+
+	NAME "Pause-Printer Operation"
+	
+	Operation Pause-Printer
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri                                                             
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+{
+	SKIP-IF-NOT-DEFINED PAUSE_PRINTER_SUPPORTED
+
+	NAME "Get-Printer-Attributes Operation to check paused value of printer-state-reasons"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR keyword requested-attributes "printer-state-reasons"
+
+	STATUS successful-ok
+
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "paused"
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "moving-to-paused"
+}
+
+#Resume-Printer operation
+{
+	SKIP-IF-NOT-DEFINED OPTIONAL_RESUME_PRINTER
+
+	Name "Resume-Printer"
+
+	Operation Resume-Printer
+
+	Group operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	Status successful-ok
+}
+
+
+
+#test for Hold-New-Jobs operation
+{
+	SKIP-IF-NOT-DEFINED HOLD_NEW_JOBS_SUPPORTED
+
+	NAME "RFC 3998 section 3.3.1: Hold-New-Jobs Operation"
+	OPERATION Hold-New-Jobs
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}  
+
+
+# Test Print-Job operation - This job should be put into the pending-held state
+{
+	SKIP-IF-NOT-DEFINED HOLD_NEW_JOBS_SUPPORTED
+	
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_HELDJOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 4        #expecting the pending-held job-state message.
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#test the "hold-new-jobs" value of the printer-state-reason attribute
+{
+	SKIP-IF-NOT-DEFINED HOLD_NEW_JOBS_SUPPORTED
+
+	NAME "Get-Printer-Attributes Operation to check hold-new-jobs value of printer-state-reasons"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR keyword requested-attributes "printer-state-reasons"
+
+	STATUS successful-ok
+
+	EXPECT printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "hold-new-jobs"
+}
+
+#test for Release-Held-New-Jobs Operation
+{
+	SKIP-IF-NOT-DEFINED RELEASE_HELD_NEW_JOBS_SUPPORTED
+
+	NAME "RFC 3998 section 3.3.2: Release-Held-New-Jobs Operation"
+	OPERATION Release-Held-New-Jobs 
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+
+# Wait for job to complete...( to check if the earlier job held has been competed )
+{
+	SKIP-IF-NOT-DEFINED JOBID_HELDJOB
+
+	NAME "Get-Job-Attributes Until Job Complete"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_HELDJOB
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+	DISPLAY job-state
+}
+
+#test for the Deactivate-Printer Operation
+{
+	SKIP-IF-NOT-DEFINED DEACTIVATE_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.4.1: Deactivate-Printer Operation"
+	OPERATION Deactivate-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+# Test Print-Job operation after de-activating printer. Printer is not supposed to accept any job-creation operation after deactivating. Must return a server-error-service unavailable
+{
+	SKIP-IF-NOT-DEFINED DEACTIVATE_PRINTER_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag 
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS server-error-service-unavailable
+}
+
+#test the "paused" and "deactivated" value of the printer-state-reason attribute
+{
+	SKIP-IF-NOT-DEFINED DEACTIVATE_PRINTER_SUPPORTED
+
+	NAME "Get-Printer-Attributes Operation to check paused value of printer-state-reasons"
+	OPERATION Get-Printer-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR keyword requested-attributes "printer-state-reasons"
+
+	STATUS successful-ok
+
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "paused"
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deactivated"
+	EXPECT ?printer-state-reasons OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "moving-to-paused"
+}
+
+
+#test for the Activate-Printer Operation
+{
+	SKIP-IF-NOT-DEFINED ACTIVATE_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.4.2: Activate-Printer Operation"
+	OPERATION Activate-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+#test for Restart-Printer Operation
+{
+	SKIP-IF-NOT-DEFINED RESTART_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.5.1: Restart-Printer Operation"
+	OPERATION Restart-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+#test for Shutdown-Printer Operation
+{
+	SKIP-IF-NOT-DEFINED SHUTDOWN_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.5.2: Shutdown-Printer Operation"
+	OPERATION Shutdown-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+#test for Startup-Printer operation
+{
+	SKIP-IF-NOT-DEFINED STARTUP_PRINTER_SUPPORTED
+
+	NAME "RFC 3998 section 3.5.3: Startup-Printer Operation"
+	OPERATION Startup-Printer
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+# Test Print-Job operation - Will be reprocessed using the Reprocess-Job operation below.
+{
+	SKIP-IF-NOT-DEFINED REPROCESS_JOB_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_REPROCESSJOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#test the Reprocess-Job Operation
+{
+	SKIP-IF-NOT-DEFINED JOBID_REPROCESSJOB
+	SKIP-IF-NOT-DEFINED REPROCESS_JOB_SUPPORTED
+
+	NAME "RFC 3998 section 4.1: Reprocess-Job Operation"
+
+	OPERATION Reprocess-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri	
+	ATTR integer job-id $JOBID_REPROCESSJOB
+
+	STATUS successful-ok
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Print-Job operation - Will be cancelled using the Cancel-Current-Job operation below.
+{
+	SKIP-IF-NOT-DEFINED CANCEL_CURRENT_JOB_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_CANCELJOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+
+#test for Cancel-Current-Job Operation
+{
+	SKIP-IF-NOT-DEFINED CANCEL_CURRENT_JOB_SUPPORTED
+
+	NAME "RFC 3998 section 4.2: Cancel-Current-Job Operation"
+
+	OPERATION Cancel-Current-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri	
+	ATTR integer job-id $JOBID_CANCELJOB
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+# Test Print-Job operation - Will be suspended using the Suspend-Current-Job operation below.
+{
+	SKIP-IF-NOT-DEFINED SUSPEND_CURRENT_JOB_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_SUSPENDJOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#test for Suspend-Current-Job Operation
+{
+	SKIP-IF-NOT-DEFINED SUSPEND_CURRENT_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_SUSPENDJOB
+
+	NAME "RFC 3998 section 4.3.1: Suspend-Current-Job Operation"
+
+	OPERATION Suspend-Current-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri	
+	ATTR integer job-id $JOBID_SUSPENDJOB
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+#test to confirm the suspension of the job
+{	
+	SKIP-IF-NOT-DEFINED JOBID_SUSPENDJOB
+
+	NAME "Get-Job-Attributes -Check if job is suspended"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_SUSPENDJOB
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE 6 
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE "job-suspended" 
+	DISPLAY job-state
+}
+
+#test for Resume-Job operation
+{
+	SKIP-IF-NOT-DEFINED RESUME_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_SUSPENDJOB
+
+	NAME "RFC 3998 section 4.3.2: Resume-Job Operation"
+
+	OPERATION Resume-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri	
+	ATTR integer job-id $JOBID_SUSPENDJOB
+
+	STATUS successful-ok
+	STATUS client-error-not-possible	
+}
+
+# Wait for job to complete... The job had been released so it sholud complete now. Confirming the same with the below test.
+{
+	SKIP-IF-NOT-DEFINED JOBID_SUSPENDJOB
+
+	NAME "Get-Job-Attributes Until Job Complete"
+	OPERATION Get-Job-Attributes
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $JOBID_SUSPENDJOB
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+	DISPLAY job-state
+}
+
+#testing the Promote-Job Operation
+# Print-Job operation 
+{
+	SKIP-IF-NOT-DEFINED PROMOTE_JOB_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+# Test Print-Job operation - Will be promoted using the Promote-Job operation below.
+{
+	SKIP-IF-NOT-DEFINED PROMOTE_JOB_SUPPORTED
+
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_PROMOTEJOB
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+
+#tests for Promote-Job Operation. 
+{
+	SKIP-IF-NOT-DEFINED PROMOTE_JOB_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_PROMOTEJOB
+
+	NAME "RFC 3998 section 4.4.1: Promote-Job"
+	OPERATION Promote-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+}
+
+
+#testing the Schedule-Job-After Operation
+{
+	SKIP-IF-NOT-DEFINED SCHEDULE_JOB_AFTER_SUPPORTED
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_PREDECESSOR
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+{
+	SKIP-IF-NOT-DEFINED SCHEDULE_JOB_AFTER_SUPPORTED
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+{
+	SKIP-IF-NOT-DEFINED SCHEDULE_JOB_AFTER_SUPPORTED
+	NAME "RFC 8011 section 4.2.1: Print-Job Operation"
+	OPERATION Print-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name job-name $filename
+	ATTR boolean ipp-attribute-fidelity false
+	ATTR name document-name $filename
+	ATTR keyword compression none
+	ATTR mimeMediaType document-format $filetype
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS client-error-document-format-not-supported
+	STATUS server-error-job-canceled
+	STATUS server-error-busy REPEAT-MATCH REPEAT-LIMIT 30
+
+	EXPECT job-uri OF-TYPE uri COUNT 1 IN-GROUP job-attributes-tag WITH-VALUE "$IPP_URI_SCHEME"
+	EXPECT job-id OF-TYPE integer COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE >0 DEFINE-VALUE JOBID_TARGET
+	EXPECT job-state OF-TYPE unknown|enum COUNT 1 IN-GROUP job-attributes-tag
+	       WITH-VALUE 3,4,5,6,7,8,9
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+	EXPECT ?job-state-message OF-TYPE text IN-GROUP job-attributes-tag
+	EXPECT ?number-of-intervening-jobs OF-TYPE integer
+	       IN-GROUP job-attributes-tag WITH-VALUE >-1
+}
+
+#Test for Schedule-Job-After Operation
+{
+	SKIP-IF-NOT-DEFINED SCHEDULE_JOB_AFTER_SUPPORTED
+	SKIP-IF-NOT-DEFINED JOBID_TARGET
+	SKIP-IF-NOT-DEFINED JOBID_PREDECESSOR
+
+	NAME "RFC 3998 section 4.4.1: Promote-Job"
+	OPERATION Promote-Job
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer predecessor-job-id $JOBID_PREDECESSOR
+	ATTR integer job-id $JOBID_TARGET
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	STATUS client-error-not-possible
+	STATUS client-error-not-found
+}
+
+


### PR DESCRIPTION
The pull request contains the entire work done by me as part of GSoC 2018 in the project- Enhancements for Ipptool. The work includes 9 test files testing various attributes and operations based on the following:

1. RFC 8011: IPP/1.1 Model and Semantics
1. RFC 3998: IPP Job and Printer Administrative Operations
1. RFC 3380: IPP: Job and Printer Set Operations
1. PWG 5100.21-2017: IPP 3D Printing Extensions v1.0 (3D)
1. PWG 5100.17-2014: IPP Scan Service
1. PWG 5100.15-2014: IPP FaxOut Service
1. PWG 5100.16-2013: IPP Transaction-Based Printing Extensions
1. Test Files for PWG 5100.2-2001: "output-bin" attribute extension
1. PWG 5100.8-2003: IPP "-actual" attributes

@michaelrsweet Can you please review the same