### PR TITLE
add testfiles in example directory

### DIFF
--- a/examples/pwg5100.1.test
+++ b/examples/pwg5100.1.test
@@ -1,0 +1,225 @@
+#
+#Check a printer for conformance with PWG 5100.1
+#
+#
+#Usage:
+#
+#	./ipptool -f FILENAME printer-uri pwg5100.1.1.test
+#
+
+{
+    NAME "Get-printer-attributes to check finishings-supported values"
+
+    OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+    EXPECT finishings-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FINISHINGS_COL
+    EXPECT finishings-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE finishing-template DEFINE-MATCH HAVE_FINISHING_TEMPLATE       # finishing-template
+    EXPECT finishings-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE stitching DEFINE-MATCH HAVE_STITCH                            # stitch
+
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3                               # none
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 4 DEFINE-MATCH HAVE_STAPLE      # staple
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 5 DEFINE-MATCH HAVE_PUNCH       # punch
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 6 DEFINE-MATCH HAVE_COVER       # cover    
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 7 DEFINE-MATCH HAVE_BIND        # bind
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 10 DEFINE-MATCH HAVE_FOLD       # fold
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 11 DEFINE-MATCH HAVE_TRIM       # trim
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 12 DEFINE-MATCH HAVE_BALE       # bale
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 15 DEFINE-MATCH HAVE_COAT       # coat
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 16 DEFINE-MATCH HAVE_LAMINATE   # laminate
+    
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_FINISHINGS_COL
+
+    NAME "Get-printer-attributes to check finishings-col members support"
+
+    OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+    EXPECT bailing-type-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_BALE
+    EXPECT bailing-when-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_BALE
+    EXPECT binding-reference-edge-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_BIND
+    EXPECT binding-type-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_BIND
+    EXPECT coating-sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_COAT
+    EXPECT coating-type-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_COAT
+    EXPECT covering-name-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_COVER 
+    EXPECT finishing-template-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FINISHING_TEMPLATE
+    EXPECT folding-direction-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FOLD
+    EXPECT folding-offset-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_FOLD
+    EXPECT folding-reference-edge-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FOLD
+    EXPECT laminating-sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_LAMINATE
+    EXPECT laminating-type-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_LAMINATE
+    
+    EXPECT ?printer-finisher OF-TYPE octetString IN-GROUP printer-attributes-tag
+    EXPECT ?printer-finisher-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-finisher
+    EXPECT ?printer-finisher-supplies OF-TYPE octetString IN-GROUP printer-attributes-tag
+    EXPECT ?printer-finisher-supplies-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-finisher-supplies        
+    EXPECT ?punching-hole-diameter-configured OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >-1
+    EXPECT punching-locations-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_PUNCH
+    EXPECT punching-offset-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_PUNCH
+    EXPECT punching-reference-edge-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_PUNCH
+    EXPECT stitching-angle-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1, <360 IF-DEFINED HAVE_STITCH
+    EXPECT stitching-locations-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_STITCH
+    EXPECT stitching-method-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_STITCH
+    EXPECT stitching-offset-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_STITCH
+    EXPECT stitching-reference-edge-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_STITCH
+    EXPECT trimming-offset-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE >-1 IF-DEFINED HAVE_TRIM    
+    EXPECT trimming-reference-edge-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_TRIM    
+    EXPECT trimming-type-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_TRIM
+    EXPECT trimming-when-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_TRIM
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_STAPLE
+
+	NAME "Checking staple finishing"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR enum finishings 4  #staple
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_STAPLE
+
+	NAME "Get job info with get-job-attributes"
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+	EXPECT finishings OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 4 COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PUNCH
+
+	NAME "Checking punch finishing"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR enum finishings 5  # punch
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PUNCH
+
+	NAME "Get job info with get-job-attributes"
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+	EXPECT finishings OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 5 COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_FOLD
+
+	NAME "Checking fold finishing"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR enum finishings 10  # fold
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_FOLD
+
+	NAME "Get job info with get-job-attributes"
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+	EXPECT finishings OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 10 COUNT 1
+}

--- a/examples/pwg5100.11.test
+++ b/examples/pwg5100.11.test
@@ -1,0 +1,116 @@
+#
+#Check a printer for conformance with pwg5100.11
+#
+#
+#Usage:
+#
+#	./ipptool -f FILENAME printer-uri pwg5100.11.3.test
+#
+
+{
+    # get printer attributes and check support for REQUIRED attributes
+
+	NAME "Get printer attributes using Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+    
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0038 # Cancel-Jobs
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0039 # Cancel-My-Jobs
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x003B # Close-Job
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x003A # Resubmit-Job
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x002C # Reprocess-Job
+
+    EXPECT job-ids-supported OF-TYPE boolean IN-GROUP printer-attributes-tag WITH-VALUE "true" COUNT 1   # To check the job-ids operation-attribute support in Get-Jobs and Purge-Jobs
+
+    EXPECT proof-print-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE proof-print-copies                              #
+    EXPECT proof-print-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE media                                           #
+                                                                                                                                            # checking proof-print and related attributes.
+    EXPECT proof-print-default OF-TYPE collection|no-value IN-GROUP printer-attributes-tag                                                  #
+                                                                                                                                            #
+    EXPECT which-jobs-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE completed                                        #
+    EXPECT which-jobs-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE not-completed                                    #
+    EXPECT which-jobs-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE saved                                            #
+
+    EXPECT ?job-hold-until-time-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_JOB_HOLD_UNTIL_TIME
+    EXPECT ?job-delay-output-until-time-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_JOB_DELAY_OUTPUT_UNTIL_TIME
+    EXPECT ?job-delay-output-until-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_JOB_DELAY_OUTPUT_UNTIL
+    
+    EXPECT job-hold-until-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_JOB_HOLD_UNTIL_TIME
+    EXPECT job-hold-until-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE-FROM job-hold-until-supported COUNT 1 IF-DEFINED HAVE_JOB_HOLD_UNTIL_TIME
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x000C IF-DEFINED HAVE_JOB_HOLD_UNTIL_TIME                                              # Hold-Job
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x000D IF-DEFINED HAVE_JOB_HOLD_UNTIL_TIME                                              # Release-Job
+
+    EXPECT job-delay-output-until-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_JOB_DELAY_OUTPUT_UNTIL_TIME
+    EXPECT job-delay-output-until-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE-FROM job-delay-output-until-supported COUNT 1 IF-DEFINED HAVE_JOB_DELAY_OUTPUT_UNTIL_TIME
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0014 IF-DEFINED HAVE_JOB_DELAY_OUTPUT_UNTIL_TIME                                      # Set-job-attributes
+
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0014 IF-DEFINED HAVE_JOB_DELAY_OUTPUT_UNTIL                                           # Set-job-attributes
+}
+
+{
+    NAME "print-job with proof-print"
+    OPERATION Print-Job
+
+    GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR collection proof-print {
+        MEMBER integer proof-print-copies 1
+        MEMBER keyword media letterhead
+    }
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+# Wait for job to complete...
+
+{
+    NAME "Get-Job-Attributes Until Job Complete"
+    OPERATION Get-Job-Attributes
+    
+    GROUP operation-attributes-tag
+    ATTR charset attributes-charset utf-8
+    ATTR naturalLanguage attributes-natural-language en
+    ATTR uri printer-uri $uri
+    ATTR integer job-id $job-id
+    ATTR name requesting-user-name $user
+
+    STATUS successful-ok
+
+    EXPECT proof-print OF-TYPE collection IN-GROUP job-attributes-tag COUNT 1
+    EXPECT proof-print/proof-print-copies OF-TYPE integer WITH-VALUE 1 COUNT 1
+    EXPECT proof-print/media OF-TYPE keyword WITH-VALUE letterhead COUNT 1
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+}
+
+{
+    NAME "Resubmit proof-print job"
+    OPERATION Resubmit-Job
+
+    GROUP operation-attributes-tag
+    ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+    ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+    STATUS successful-ok
+}

--- a/examples/pwg5100.3.test
+++ b/examples/pwg5100.3.test
@@ -1,0 +1,66 @@
+#
+#Check a printer for conformance with pwg5100.3: Production Printing Attributes - Set 1
+#
+#
+#Usage:
+#
+#	./ipptool printer-uri pwg5100.3.1.test
+#
+{
+	NAME "Get printer attributes"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+# Checking which optional attributes (Section 7.1 pwg5100.3 Column 1) are satisfied.
+
+    EXPECT cover-back-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_COVER_BACK
+    EXPECT finishings-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FINISHINGS_COL
+    EXPECT finishings-col-ready OF-TYPE collection IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FINISHINGS_COL_READY    
+    EXPECT job-sheets-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_JOB_SHEETS_COL
+    EXPECT media-col-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_MEDIA_COL    
+    EXPECT media-col-ready OF-TYPE collection IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_MEDIA_COL_READY
+    EXPECT media-input-tray-check-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_MEDIA_INPUT_TRAY_CHECK 
+    EXPECT x-side2-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_X_SIDE2_IMAGE_SHIFT
+    EXPECT y-side2-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_Y_SIDE2_IMAGE_SHIFT
+    EXPECT x-side1-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_X_SIDE1_IMAGE_SHIFT
+    EXPECT y-side1-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_Y_SIDE1_IMAGE_SHIFT
+
+# Ensuring that attributes which become conditionally required (Section 7.1 pwg5100.3 Column 2) are present when corresponding condition is satisfied.
+
+    EXPECT cover-front-supported OF-TYPE keyword IN-GROUP printer-attributes-tag IF-DEFINED HAVE_COVER_BACK DEFINE-MATCH HAVE_COVER_FRONT
+    EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FINISHINGS_COL DEFINE-MATCH HAVE_FINISHINGS
+    EXPECT finishings-ready OF-TYPE enum IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FINISHINGS_COL_READY DEFINE-MATCH HAVE_FINISHINGS_READY
+    EXPECT job-sheets-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_JOB_SHEETS_COL DEFINE-MATCH HAVE_JOB_SHEETS
+    EXPECT media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_MEDIA_COL DEFINE-MATCH HAVE_MEDIA
+    EXPECT media-ready OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_MEDIA_COL_READY DEFINE-MATCH HAVE_MEDIA_READY
+    EXPECT media-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag IF-DEFINED HAVE_MEDIA_INPUT_TRAY_CHECK DEFINE-MATCH HAVE_MEDIA    
+    EXPECT x-side1-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED HAVE_X_SIDE2_IMAGE_SHIFT DEFINE-MATCH HAVE_X_SIDE1_IMAGE_SHIFT
+    EXPECT y-side1-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED HAVE_Y_SIDE2_IMAGE_SHIFT DEFINE-MATCH HAVE_Y_SIDE1_IMAGE_SHIFT
+    EXPECT x-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED HAVE_X_SIDE1_IMAGE_SHIFT DEFINE-MATCH HAVE_X_IMAGE_SHIFT
+    EXPECT y-image-shift-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag IF-DEFINED HAVE_Y_SIDE1_IMAGE_SHIFT DEFINE-MATCH HAVE_y_IMAGE_SHIFT
+
+# Ensuring that xxx-default attributes (if present) satisfy conformance requirements.
+
+    EXPECT ?cover-back-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?finishings-col-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?job-sheets-col-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?media-col-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?media-input-tray-check-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?x-side2-image-shift-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?y-side2-image-shift-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?x-side1-image-shift-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?y-side1-image-shift-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+    
+    EXPECT ?cover-front-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE-FROM finishings-supported
+    EXPECT ?job-sheets-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag WITH-VALUE-FROM job-sheets-supported COUNT 1
+    EXPECT ?media-default OF-TYPE no-value|keyword|name IN-GROUP printer-attributes-tag WITH-VALUE-FROM media-supported COUNT 1
+    EXPECT ?x-image-shift-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?y-image-shift-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
+}

--- a/examples/pwg5100.5.test
+++ b/examples/pwg5100.5.test
@@ -1,0 +1,258 @@
+#
+#Check a printer for conformance with pwg5100.5: IPP Document Object
+#
+#
+#Usage:
+#
+#	./ipptool -f FILENAME -d "document-uri=URI" printer-uri pwg5100.5.2.test
+#
+{
+	NAME "Get printer attributes using Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0037 DEFINE-MATCH HAVE_SET_DOCUMENT_ATTRIBUTES	# Set-Document-Attributes
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0003 DEFINE-MATCH HAVE_PRINT_URI                  # Print-URI
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0007 DEFINE-MATCH HAVE_SEND_URI		            # Send-URI
+
+	# Checking REQUIRED attributes.
+
+	EXPECT attributes-charset-supported OF-TYPE charset IN-GROUP printer-attributes-tag
+	EXPECT attributes-natural-language-supported OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag
+
+	EXPECT document-creation-attributes-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+
+#ISSUE: attributes-charset-supported, attributes-natural-language-supported and document-creation-attributes-supported NOT PRESENT.
+
+}
+
+# testing document operations
+
+{
+	NAME "print-job to create document object"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+
+	ATTR name document-name "test-document-1"
+
+	FILE $filename
+
+	STATUS successful-ok
+	STATUS successful-ok-ignored-or-substituted-attributes
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+}
+
+{
+	NAME "Get document attributes"
+	OPERATION Get-Document-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR integer document-number 1
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	EXPECT document-job-id OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT document-job-uri OF-TYPE uri IN-GROUP document-attributes-tag COUNT 1
+	EXPECT document-name OF-TYPE name IN-GROUP document-attributes-tag WITH-VALUE "test-document-1" COUNT 1
+	EXPECT document-number OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE 1 COUNT 1
+	EXPECT document-printer-uri OF-TYPE uri IN-GROUP document-attributes-tag WITH-VALUE $uri COUNT 1
+	EXPECT document-state OF-TYPE enum IN-GROUP document-attributes-tag
+	EXPECT document-state-reasons OF-TYPE keyword IN-GROUP document-attributes-tag
+
+	EXPECT printer-up-time OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT time-at-completed OF-TYPE integer|no-value IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT time-at-created OF-TYPE integer|no-value IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT time-at-processing OF-TYPE integer|no-value IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+
+#ISSUE: printer-up-time NOT PRESENT.
+
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_SET_DOCUMENT_ATTRIBUTES
+
+	NAME "Set Document Attributes"
+	OPERATION Set-Document-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR integer document-number 1
+	ATTR name requesting-user-name $user
+
+	GROUP document-attributes-tag
+	ATTR name document-name "test-document-2" 
+
+	STATUS successful-ok
+
+#ISSUE: got server-error-operation-not-supported. 
+#	 	(set-document-attributes is listed in operations-supported attribute in get-printer-attributes response.)
+
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_SET_DOCUMENT_ATTRIBUTES
+
+	NAME "Get document attributes"
+	OPERATION Get-Document-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR integer document-number 1
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	EXPECT document-job-id OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT document-job-uri OF-TYPE uri IN-GROUP document-attributes-tag COUNT 1
+	EXPECT document-name OF-TYPE name IN-GROUP document-attributes-tag WITH-VALUE "test-document-2" COUNT 1
+	EXPECT document-number OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE 1 COUNT 1
+	EXPECT document-printer-uri OF-TYPE uri IN-GROUP document-attributes-tag WITH-VALUE $uri COUNT 1
+	EXPECT document-state OF-TYPE enum IN-GROUP document-attributes-tag
+	EXPECT document-state-reasons OF-TYPE keyword IN-GROUP document-attributes-tag
+}
+
+{
+	NAME "Create job"
+    RESOURCE /admin
+	OPERATION create-job
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	GROUP job
+	ATTR integer copies 1
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	NAME "testing document-attributes in send-document operation"
+	OPERATION send-document
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR boolean last-document false
+
+	GROUP job
+	ATTR integer copies 1
+
+	FILE $filename
+
+	STATUS successful-ok
+
+    EXPECT document-number OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT document-state OF-TYPE enum IN-GROUP document-attributes-tag
+    EXPECT document-state-reasons OF-TYPE keyword IN-GROUP document-attributes-tag
+
+#ISSUE: document-number, document-state, and document-state-reasons NOT PRESENT.
+
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_SEND_URI
+
+	NAME "testing document-attributes in send-uri operation"
+	OPERATION Send-URI
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user	
+	ATTR boolean last-document true
+	ATTR uri document-uri $document-uri
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+
+	STATUS successful-ok
+	EXPECT document-number OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT document-state OF-TYPE enum IN-GROUP document-attributes-tag
+    EXPECT document-state-reasons OF-TYPE keyword IN-GROUP document-attributes-tag
+
+#ISSUE: document-number, document-state, and document-state-reasons NOT PRESENT.
+
+}
+
+{
+	NAME "testing cancel-document operation"
+	OPERATION Cancel-Document
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR integer document-number 1
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+#ISSUE: got server-error-operation-not-supported. 
+#	 	(cancel-document is listed in operations-supported attribute in get-printer-attributes response.)
+
+}
+
+{
+	NAME "Get document attributes"
+	OPERATION Get-Document-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR integer document-number 1
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	EXPECT document-job-id OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT document-job-uri OF-TYPE uri IN-GROUP document-attributes-tag COUNT 1
+	EXPECT document-number OF-TYPE integer IN-GROUP document-attributes-tag WITH-VALUE 1 COUNT 1
+	EXPECT document-printer-uri OF-TYPE uri IN-GROUP document-attributes-tag WITH-VALUE $uri COUNT 1
+	EXPECT ?document-state OF-TYPE enum IN-GROUP document-attributes-tag WITH-VALUE 5 COUNT 1 DEFINE-MATCH DOCUMENT_PROCESSING			# processing
+	EXPECT document-state OF-TYPE enum IN-GROUP document-attributes-tag WITH-VALUE 7 COUNT 1 IF-NOT-DEFINED DOCUMENT_PROCESSING 		# cancelled
+	EXPECT document-state-reasons OF-TYPE keyword IN-GROUP document-attributes-tag WITH-VALUE "processing-to-stop-print" IF-DEFINED DOCUMENT_PROCESSING
+}
+

--- a/examples/pwg5100.6.test
+++ b/examples/pwg5100.6.test
@@ -1,0 +1,629 @@
+#
+#Check a printer for conformance with PWG 5100.6-2003
+#
+#
+#Usage:
+#
+#	./ipptool -f FILENAME -d "document-uri=URI" printer-uri pwg5100.6.4.test
+# 	(need to provide document-uri only if print-uri or send-uri operations are supported by printer.)
+#	(the file having name FILENAME and the document specified by document-uri should have atleast 4 pages.)
+#
+
+{
+    # get printer attributes and check support for REQUIRED attributes
+
+	NAME "Get printer attributes using Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE pages
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE document-numbers
+	EXPECT overrides-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag WITH-VALUE document-copies DEFINE-MATCH HAVE_DOCUMENT_COPIES
+
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE finishings DEFINE-MATCH HAVE_FINISHINGS
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE media-col DEFINE-MATCH HAVE_MEDIA_COL
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE sides DEFINE-MATCH HAVE_SIDES
+
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0005 DEFINE-MATCH HAVE_CREATE_JOB		# Create-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0003 DEFINE-MATCH HAVE_PRINT_URI		# Print-URI
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0007 DEFINE-MATCH HAVE_SEND_URI		# Send-URI
+}
+
+{
+	# A print-job request valid for all conforming printers.
+
+	NAME "Checking overrides on print-job request - 1"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+	}
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+}
+
+{
+	# A print-job request for printers not supporting document-copies override.
+	# But the document-copies value has been supplied.
+	# Also, ipp-attribute-fidelity is false.
+	# Therefore the client must accept the request.
+	# The status should be successful-ok-ignored-or-substituted-attributes.
+
+	SKIP-IF-DEFINED HAVE_DOCUMENT_COPIES
+
+	NAME "Checking overrides on print-job request - 2"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER rangeOfInteger document-copies 1-2
+	}
+
+	FILE $filename
+
+	STATUS successful-ok-ignored-or-substituted-attributes
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-DEFINED HAVE_DOCUMENT_COPIES
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+}
+
+{
+	# A print-job request for printers not supporting document-copies override.
+	# But the document-copies value has been supplied.
+	# Also, ipp-attribute-fidelity is true.
+	# Therefore the client must reject the request.
+	# The status should be client-error-attributes-or-values-not-supported.
+
+	SKIP-IF-DEFINED HAVE_DOCUMENT_COPIES
+
+	NAME "Checking overrides on print-job request - 3"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity true
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER rangeOfInteger document-copies 1-2
+	}
+
+	FILE $filename
+
+	STATUS client-error-attributes-or-values-not-supported
+}
+
+{
+    # wait for job to complete..
+
+    NAME "Get-Job-Attributes Until Job Complete"
+    OPERATION Get-Job-Attributes
+    
+    GROUP operation-attributes-tag
+    ATTR charset attributes-charset utf-8
+    ATTR naturalLanguage attributes-natural-language en
+    ATTR uri printer-uri $uri
+    ATTR integer job-id $job-id
+    ATTR name requesting-user-name $user
+
+    EXPECT ?job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+}
+
+# testing support for overrides on Send-Document operation
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+
+	NAME "create-job"
+	OPERATION create-job
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+
+	NAME "send-document"
+	OPERATION send-document
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+	ATTR boolean last-document true
+
+	GROUP job
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+	}
+
+	FILE $filename
+
+	STATUS successful-ok
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+}
+
+
+# testing support for overrides on Print-URI operation
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_PRINT_URI
+
+	NAME "Print file using Print-URI"
+	OPERATION Print-URI
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name document-name $document-uri
+	ATTR uri document-uri $document-uri
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+	}
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_PRINT_URI
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP operation-attributes-tag WITH-VALUE 1-1 COUNT 1
+}
+
+# testing support for overrides on Send-URI operation
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+	SKIP-IF-NOT-DEFINED HAVE_SEND_URI
+
+	NAME "create-job"
+	OPERATION Create-Job
+	
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+	SKIP-IF-NOT-DEFINED HAVE_SEND_URI
+
+	NAME "send-uri"
+	OPERATION Send-URI
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user	
+	ATTR boolean last-document true
+	ATTR uri document-uri $document-uri
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+	}
+
+	STATUS successful-ok
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+	SKIP-IF-NOT-DEFINED HAVE_SEND_URI
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_FINISHINGS
+	SKIP-IF-NOT-DEFINED HAVE_SIDES
+	SKIP-IF-NOT-DEFINED HAVE_MEDIA_COL
+
+	NAME "Checking finishings, sides, and media-col override"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER enum finishings 4 						# staple.
+		MEMBER keyword sides two-sided-long-edge
+	},
+	
+	{
+		MEMBER rangeOfInteger pages 3-4
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER collection media-col {
+			MEMBER keyword media-type envelope 
+		}
+	}
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_FINISHINGS
+	SKIP-IF-NOT-DEFINED HAVE_SIDES
+	SKIP-IF-NOT-DEFINED HAVE_MEDIA_COL
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 2
+	EXPECT overrides/finishings OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 4 COUNT 1
+	EXPECT overrides/sides OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE two-sided-long-edge COUNT 1
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 3-4 COUNT 1
+	EXPECT overrides/media-col/media-type OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE envelope COUNT 1
+}
+
+
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_FINISHINGS
+
+	NAME "Checking finishings override"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER enum finishings 4 		# staple.
+	}
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_FINISHINGS
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+	EXPECT overrides/finishings OF-TYPE enum IN-GROUP job-attributes-tag WITH-VALUE 4 COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_MEDIA_COL
+
+	NAME "Checking media-col override."
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-1
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER collection media-col {
+			MEMBER keyword media-type letterhead
+		}
+	}
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_MEDIA_COL
+
+	NAME "Get job info with get-job-attributes"
+
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+	EXPECT overrides/media-col/media-type OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE fold COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_SIDES
+
+	NAME "Checking sides override."
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+	ATTR boolean ipp-attribute-fidelity false
+
+	GROUP job-attributes-tag
+	ATTR integer copies 2
+	ATTR collection overrides {
+		MEMBER rangeOfInteger pages 1-2
+		MEMBER rangeOfInteger document-numbers 1-1
+		MEMBER keyword sides two-sided-long-edge
+	}
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED HAVE_SIDES
+
+	NAME "Get job info with get-job-attributes"
+	OPERATION Get-Job-Attributes
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+    EXPECT job-state OF-TYPE unknown|enum IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE >6 REPEAT-NO-MATCH REPEAT-LIMIT 30
+    DISPLAY job-state
+
+	EXPECT overrides/pages OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-2 COUNT 1
+	EXPECT overrides/document-numbers OF-TYPE rangeOfInteger IN-GROUP job-attributes-tag WITH-VALUE 1-1 COUNT 1
+	EXPECT overrides/sides OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE two-sided-long-edge COUNT 1
+}

--- a/examples/pwg5100.7.test
+++ b/examples/pwg5100.7.test
@@ -1,0 +1,321 @@
+#
+#Check a printer for conformance with PWG 5100.7-2003 Standard for IPP: Job Extensions
+#
+#
+#Usage:
+#
+#	./ipptool -f FILENAME -d output-device=OUTPUT_DEVICE printer-uri pwg5100.7.test
+#
+{
+    # get printer attributes
+
+	NAME "Get printer attributes using Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+# Operation attributes (xxx-supported and xxx-default) for job creation and document creation operations
+
+    EXPECT ?document-charset-supported OF-TYPE charset IN-GROUP printer-attributes-tag
+    EXPECT ?document-digital-signature-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+    EXPECT ?document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag
+    EXPECT ?document-format-version-supported OF-TYPE text IN-GROUP printer-attributes-tag
+    EXPECT ?document-natural-language-supported OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag
+    EXPECT ?document-format-details-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+
+    EXPECT ?document-charset-default OF-TYPE charset IN-GROUP printer-attributes-tag WITH-VALUE-FROM document-charset-supported COUNT 1
+    EXPECT ?document-digital-signature-default OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE-FROM document-digital-signature-supported COUNT 1
+    EXPECT ?document-format-default OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE-FROM document-format-supported COUNT 1
+    EXPECT ?document-format-version-default OF-TYPE text IN-GROUP printer-attributes-tag WITH-VALUE-FROM document-format-version-supported COUNT 1
+    EXPECT ?document-natural-language-default OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag WITH-VALUE-FROM document-natural-language-supported COUNT 1
+    EXPECT ?document-format-details-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+
+# Job template attributes (xxx-supported and xxx-default)
+
+    EXPECT ?job-copies-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag
+    EXPECT ?job-cover-back-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+    EXPECT ?job-cover-front-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+    EXPECT ?job-finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag
+    EXPECT ?job-finishings-col-supported OF-TYPE collection IN-GROUP printer-attributes-tag
+    EXPECT ?print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
+    EXPECT output-device-supported OF-TYPE name IN-GROUP printer-attributes-tag DEFINE-MATCH SUPPORT_OUTPUT_DEVICE
+
+    EXPECT ?job-copies-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT ?job-cover-back-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?job-cover-front-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?job-finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE-FROM job-finishings-supported COUNT 1
+    EXPECT ?job-finishings-col-default OF-TYPE collection IN-GROUP printer-attributes-tag COUNT 1
+    EXPECT ?print-content-optimize-default OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE-FROM print-content-optimize-supported COUNT 1 DEFINE-MATCH HAVE_PRINT_CONTENT_OPTIMIZE
+	
+	EXPECT ?print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "photo" COUNT 1 DEFINE-MATCH PHOTO_PRINT_CONTENT
+	EXPECT ?print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "graphics" COUNT 1 DEFINE-MATCH GRAPHICS_PRINT_CONTENT
+	EXPECT ?print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "text" COUNT 1 DEFINE-MATCH TEXT_PRINT_CONTENT
+	EXPECT ?print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "text-and-graphics" COUNT 1 DEFINE-MATCH TEXT_AND_GRAPHICS_PRINT_CONTENT
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED PHOTO_PRINT_CONTENT
+
+	NAME "Print using print-content-optimize (photo)"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name document-name color.jpg
+	ATTR mimeMediaType document-format image/jpeg
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR keyword print-content-optimize photo
+
+	FILE color.jpg
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED PHOTO_PRINT_CONTENT
+
+    NAME "Get job attributes"
+    OPERATION Get-Job-Attributes
+
+    GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+    EXPECT print-content-optimize OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE photo COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED GRAPHICS_PRINT_CONTENT
+
+	NAME "Print using print-content-optimize (graphics)"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name document-name testfile.ps					# might need to choose some other file than testfile.ps (vector file)
+	ATTR mimeMediaType document-format application/postscript
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR keyword print-content-optimize graphics
+
+	FILE testfile.ps
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED GRAPHICS_PRINT_CONTENT
+
+    NAME "Get job attributes"
+    OPERATION Get-Job-Attributes
+
+    GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+    EXPECT print-content-optimize OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE graphics COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED TEXT_PRINT_CONTENT
+
+	NAME "Print using print-content-optimize (text)"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name document-name testfile.txt
+	ATTR mimeMediaType document-format text/plain
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR keyword print-content-optimize text
+
+	FILE testfile.txt
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED TEXT_PRINT_CONTENT
+
+    NAME "Get job attributes"
+    OPERATION Get-Job-Attributes
+
+    GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+    EXPECT print-content-optimize OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE text COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED TEXT_AND_GRAPHICS_PRINT_CONTENT
+
+	NAME "Print using print-content-optimize (text-and-graphics)"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name document-name onepage-letter.pdf				# might need to choose some other file than onepage-letter.pdf (vector file)
+	ATTR mimeMediaType document-format application/pdf
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR keyword print-content-optimize "text-and-graphics"
+
+	FILE onepage-letter.pdf
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_CONTENT_OPTIMIZE
+	SKIP-IF-NOT-DEFINED TEXT_AND_GRAPHICS_PRINT_CONTENT
+
+    NAME "Get job attributes"
+    OPERATION Get-Job-Attributes
+
+    GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+    EXPECT print-content-optimize OF-TYPE keyword IN-GROUP job-attributes-tag WITH-VALUE "text-and-graphics" COUNT 1
+}
+
+{
+	SKIP-IF-DEFINED output-device
+	SKIP-IF-NOT-DEFINED SUPPORT_OUTPUT_DEVICE
+
+	NAME "Display output-device-supported values"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+    EXPECT output-device-supported OF-TYPE name IN-GROUP printer-attributes-tag
+	DISPLAY output-device-supported
+}
+
+{
+	SKIP-IF-NOT-DEFINED output-device
+    SKIP-IF-NOT-DEFINED SUPPORT_OUTPUT_DEVICE
+
+	NAME "Print using output-device"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+    ATTR name output-device $output-device
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+}
+
+{
+	SKIP-IF-NOT-DEFINED output-device
+    SKIP-IF-NOT-DEFINED SUPPORT_OUTPUT_DEVICE
+
+    NAME "Get job attributes"
+    OPERATION Get-Job-Attributes
+
+    GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer job-id $job-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+	
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1 WITH-VALUE $job-uri
+	EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag COUNT 1
+
+    EXPECT output-device OF-TYPE name IN-GROUP job-attributes-tag WITH-VALUE $output-device COUNT 1
+}

--- a/examples/pwg5100.9.test
+++ b/examples/pwg5100.9.test
@@ -1,0 +1,23 @@
+#
+#Check a printer for conformance with PWG 5100.9
+#
+#
+#Usage:
+#
+#	./ipptool printer-uri pwg5100.9.2.test
+#	
+
+{
+	NAME "Get printer attributes to check printer-alert and printer-alert-description"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+    EXPECT printer-alert OF-TYPE octetString IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^[Cc][Oo][Dd][Ee]\=[A-Za-z]+(;([Ii][Nn][Dd][Ee][Xx]\=[0-9]+|[Ss][Ee][Vv][Ee][Rr][Ii][Tt][Yy]\=[A-Za-z]+|[Tt][Rr][Aa][Ii][Nn][Ii][Nn][Gg]\=[A-Za-z]+|[Gg][Rr][Oo][Uu][Pp]\=[A-Za-z]+|[Gg][Rr][Oo][Uu][Pp][Ii][Nn][Dd][Ee][Xx]\=[0-9]+|[Ll][Oo][Cc][Aa][Tt][Ii][Oo][Nn]\=[0-9]+|[Tt][Ii][Mm][Ee]\=[0-9]+)){0,1}$/"
+	EXPECT printer-alert-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-alert
+}

--- a/examples/rfc3995-3996.test
+++ b/examples/rfc3995-3996.test
@@ -1,0 +1,516 @@
+#
+#Check a printer for conformance with rfc3995 and rfc3996
+#
+#
+#Usage:
+#
+#	./ipptool -f FILENAME -d "document-uri=URI" printer-uri rfc3995-3996.test
+#
+{
+    # get printer attributes and check support for REQUIRED attributes
+
+	NAME "Get printer attributes using Get-Printer-Attributes"
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0016	# Create-Printer-Subscriptions
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0018	# Get-Subscription-Attributes
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0019	# Get-Subscriptions
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x001A	# Renew-Subscription
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x001B	# Cancel-Subscription
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x001C	# Get-Notifications
+
+	EXPECT notify-pull-method-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "ippget"
+	EXPECT notify-events-default OF-TYPE keyword IN-GROUP printer-attributes-tag
+	EXPECT notify-max-events-supported OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >1 COUNT 1
+	EXPECT notify-lease-duration-default OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT notify-lease-duration-supported OF-TYPE integer|rangeOfInteger IN-GROUP printer-attributes-tag WITH-ALL-VALUES >0
+
+    EXPECT notify-events-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE printer-state-changed
+    EXPECT notify-events-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE printer-stopped
+    EXPECT notify-events-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE job-state-changed
+    EXPECT notify-events-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE job-created
+    EXPECT notify-events-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE job-completed
+
+#ISSUE: none must be returned. (the test seems to work fine without expecting none. On expecting none, the result is confusing.)
+    EXPECT notify-events-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE none
+
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0003 DEFINE-MATCH HAVE_PRINT_URI                  # Print-URI
+    EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0005 DEFINE-MATCH HAVE_CREATE_JOB                 # Create-job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0017 DEFINE-MATCH HAVE_CREATE_JOB_SUBSCRIPTION    # Create-job-subscription
+
+	EXPECT ippget-event-life OF-TYPE integer IN-GROUP printer-attributes-tag WITH-VALUE >14	COUNT 1	# checking ippget-event-life
+	EXPECT ippget-event-life DEFINE-VALUE eventlife
+}
+
+{   
+    # create printer subscription
+
+	NAME "Create a pull printer subscription"
+	OPERATION Create-Printer-Subscriptions
+
+    GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+    ATTR name requesting-user-name $user
+
+    # using subscription-attributes-tag in request to check for its compatibility with printer
+
+    GROUP subscription-attributes-tag
+	ATTR keyword notify-pull-method ippget
+	ATTR keyword notify-events printer-state-changed
+    ATTR octetString notify-user-data "ippuser"
+
+	STATUS successful-ok
+
+    # expecting notify-subscription-id in group subscription-attributes-tag to check for its compatibility with printer
+
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT notify-subscription-id DEFINE-VALUE renew-cancel-id	# this id will be later used in renew-subscription and cancel-subscription operations.
+	DISPLAY notify-subscription-id
+}
+
+{
+    # get subscription attributes and check for REQUIRED attributes
+
+    NAME "Get subscription attributes"
+    OPERATION Get-subscription-attributes
+
+    GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+    ATTR integer notify-subscription-id $notify-subscription-id
+    ATTR name requesting-user-name $user
+    ATTR keyword requested-attributes all
+
+    STATUS successful-ok
+
+    EXPECT notify-pull-method OF-TYPE keyword IN-GROUP subscription-attributes-tag WITH-VALUE "ippget" COUNT 1
+	EXPECT notify-events OF-TYPE keyword IN-GROUP subscription-attributes-tag WITH-VALUE "printer-state-changed"
+
+##ISSUE (ipptool issue): notify-user-data is returned with value "ippuser" by ippserver but ipptool still displays EXPECTED: notify-user-data WITH-VALUE ippuser
+    EXPECT notify-user-data WITH-VALUE "ippuser" OF-TYPE octetString IN-GROUP subscription-attributes-tag COUNT 1
+
+#ISSUE: notify-charset and notify-natural-language are not returned.    
+	EXPECT notify-charset OF-TYPE charset IN-GROUP subscription-attributes-tag WITH-VALUE "utf-8" COUNT 1    
+	EXPECT notify-natural-language OF-TYPE naturalLanguage IN-GROUP subscription-attributes-tag WITH-VALUE "en" COUNT 1
+
+    EXPECT notify-lease-duration OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT !notify-time-interval
+    EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT notify-sequence-number OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >-1 COUNT 1
+    EXPECT notify-lease-expiration-time OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >-1 COUNT 1
+    EXPECT notify-printer-up-time OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT notify-printer-uri OF-TYPE uri IN-GROUP subscription-attributes-tag COUNT 1
+	EXPECT !notify-job-id
+    EXPECT notify-subscriber-user-name OF-TYPE name IN-GROUP subscription-attributes-tag WITH-VALUE $user COUNT 1
+	
+	EXPECT !notify-status-code
+}
+
+{
+    # disable-printer to create an event
+
+	NAME "Disable-Printer"
+
+	OPERATION Disable-Printer
+	VERSION 2.0
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+}
+
+{
+    # enable-printer to create another event and get the printer working again
+
+	NAME "Enable-Printer"
+
+	OPERATION Enable-Printer
+	VERSION 2.0
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR naturalLanguage attributes-natural-language en
+	ATTR uri printer-uri $uri
+
+	STATUS successful-ok
+}
+
+{
+	NAME "Get-Notifications conformance check (without event-wait mode)"
+	OPERATION Get-Notifications
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-subscription-ids $notify-subscription-id
+	ATTR name requesting-user-name $user
+	ATTR boolean notify-wait false
+
+	STATUS successful-ok
+
+
+    # rfc3996 requires notify-get-interval to be >= ippget-event-life value (section 5.2.1),
+    # but that doesn't seem to be right.
+    # ippserver also doesn't follow that.
+    # that is why the condition imposed here is <= ippget-event-life value.
+	EXPECT notify-get-interval OF-TYPE integer IN-GROUP operation-attributes-tag WITH-VALUE <$eventlife,=$eventlife COUNT 1					
+	
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT notify-printer-uri OF-TYPE uri IN-GROUP event-notification-attributes-tag COUNT 1
+	EXPECT notify-subscribed-event OF-TYPE keyword IN-GROUP event-notification-attributes-tag WITH-VALUE printer-state-changed COUNT 1
+	
+#ISSUE: printer-up-time must be returned.
+    EXPECT printer-up-time OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE >0 COUNT 1
+							
+	EXPECT notify-sequence-number OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE >-1 COUNT 1
+	EXPECT notify-charset OF-TYPE charset IN-GROUP event-notification-attributes-tag WITH-VALUE "utf-8" COUNT 1
+	EXPECT notify-natural-language OF-TYPE naturalLanguage IN-GROUP event-notification-attributes-tag WITH-VALUE "en"
+
+#ISSUE: notify-user-data must be returned.
+	EXPECT notify-user-data OF-TYPE octetString IN-GROUP event-notification-attributes-tag WITH-VALUE "ippuser" COUNT 1   										
+
+	EXPECT notify-text OF-TYPE text IN-GROUP event-notification-attributes-tag
+	EXPECT printer-state OF-TYPE enum IN-GROUP event-notification-attributes-tag
+	EXPECT printer-state-reasons OF-TYPE keyword IN-GROUP event-notification-attributes-tag
+
+#ISSUE: printer-is-accepting-jobs must be returned. 
+	EXPECT printer-is-accepting-jobs OF-TYPE boolean IN-GROUP event-notification-attributes-tag
+}
+
+{
+    # testing job creation operations - extensions for notifications 1 - Print-Job
+
+	NAME "Print file using Print-Job"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+
+	GROUP subscription-attributes-tag
+	ATTR keyword notify-pull-method ippget
+	ATTR keyword notify-events job-completed
+    ATTR octetString notify-user-data "ippuser"
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+}
+
+{
+	NAME "Get-Notifications conformance check (including event wait mode)"
+	OPERATION Get-Notifications
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-subscription-ids $notify-subscription-id
+	ATTR name requesting-user-name $user
+	ATTR boolean notify-wait true
+
+	STATUS successful-ok
+	STATUS successful-ok-events-complete
+
+	EXPECT notify-get-interval OF-TYPE integer IN-GROUP operation-attributes-tag WITH-VALUE <$eventlife,=$eventlife COUNT 1					
+
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT notify-printer-uri OF-TYPE uri IN-GROUP event-notification-attributes-tag COUNT 1
+	EXPECT notify-subscribed-event OF-TYPE keyword IN-GROUP event-notification-attributes-tag WITH-VALUE job-completed COUNT 1
+	EXPECT printer-up-time OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE >0 COUNT 1								
+	EXPECT notify-sequence-number OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE >-1 COUNT 1
+	EXPECT notify-charset OF-TYPE charset IN-GROUP event-notification-attributes-tag WITH-VALUE "utf-8" COUNT 1
+	EXPECT notify-natural-language OF-TYPE naturalLanguage IN-GROUP event-notification-attributes-tag WITH-VALUE "en"	
+	EXPECT notify-user-data OF-TYPE octetString IN-GROUP event-notification-attributes-tag WITH-VALUE "ippuser" COUNT 1
+	EXPECT notify-text OF-TYPE text IN-GROUP event-notification-attributes-tag
+	
+#ISSUE: notify-job-id is returned but job-id is not. rfc3996 (Section 5.2) requires printer to return job-id.
+# It is very likely that there in a typographical error in the rfc and notify-job-id should be returned instead of job-id.
+    EXPECT job-id OF-TYPE integer IN-GROUP event-notification-attributes-tag WITH-VALUE $job-id COUNT 1
+	
+    EXPECT job-state OF-TYPE enum IN-GROUP event-notification-attributes-tag COUNT 1 											
+	EXPECT job-state-reasons OF-TYPE keyword IN-GROUP event-Notification-attributes-tag
+}
+
+{
+    # testing job creation operations - extensions for notifications 2 - Print-URI
+
+    SKIP-IF-NOT-DEFINED HAVE_PRINT_URI
+
+	NAME "Print file using Print-URI"
+	OPERATION Print-URI
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR name document-name $document-uri
+	ATTR uri document-uri $document-uri
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+
+    GROUP subscription-attributes-tag
+	ATTR keyword notify-pull-method ippget
+	ATTR keyword notify-events job-completed,job-created
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+}
+
+{
+    # testing job creation operations - extensions for notifications 3 - Create-Job
+
+    SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB
+
+	NAME "Print test page using create-job"
+    RESOURCE /admin
+	OPERATION create-job
+
+	GROUP operation
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+
+	GROUP job
+	ATTR integer copies 1
+
+    GROUP subscription-attributes-tag
+	ATTR keyword notify-pull-method ippget
+	ATTR keyword notify-events job-completed,job-created
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+	EXPECT job-uri OF-TYPE uri IN-GROUP job-attributes-tag COUNT 1
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+}
+
+{
+	# testing get-subscriptions operation
+
+	NAME "get-subscriptions"
+	OPERATION Get-Subscriptions
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR integer limit 10 																										# 10 is just a random value.
+	ATTR keyword requested-attributes all
+	ATTR boolean my-subscriptions true
+
+	STATUS successful-ok
+
+    EXPECT-ALL notify-pull-method OF-TYPE keyword IN-GROUP subscription-attributes-tag WITH-VALUE "ippget" COUNT 1
+    EXPECT-ALL notify-events OF-TYPE keyword
+    EXPECT notify-user-data OF-TYPE octetString IN-GROUP subscription-attributes-tag WITH-VALUE "ippuser"
+	EXPECT-ALL notify-charset OF-TYPE charset IN-GROUP subscription-attributes-tag WITH-VALUE "utf-8" COUNT 1   
+	EXPECT-ALL notify-natural-language OF-TYPE naturalLanguage IN-GROUP subscription-attributes-tag WITH-VALUE "en" COUNT 1
+    EXPECT-ALL notify-lease-duration OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT-ALL notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT-ALL notify-sequence-number OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >-1 COUNT 1
+    EXPECT-ALL notify-lease-expiration-time OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >-1 COUNT 1
+	EXPECT !notify-time-interval
+    EXPECT-ALL notify-printer-up-time OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT-ALL notify-printer-uri OF-TYPE uri IN-GROUP subscription-attributes-tag COUNT 1
+    EXPECT notify-subscriber-user-name OF-TYPE name IN-GROUP subscription-attributes-tag WITH-VALUE $user COUNT 1
+
+	EXPECT !notify-status-code
+}
+
+{
+	# testing renew-subscription operation
+
+	NAME "renew-subscription"
+	OPERATION "Renew-Subscription"
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-subscription-id $renew-cancel-id
+    ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+
+#ISSUE: notify-lease-duration value must be returned.
+	EXPECT notify-lease-duration WITH-VALUE >0
+}
+
+{
+	# testing renew-subscription operation
+
+	NAME "renew-subscription"
+	OPERATION "Renew-Subscription"
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-subscription-id $renew-cancel-id
+    ATTR name requesting-user-name $user
+
+#ISSUE: response says "bad notify-lease-duration". 0 is allowed by rfc3995 (section 11.2.6.1.2) and corresponds to infinite lease.
+#values other than 0 for notify-lease-duration also get same "bad notify-lease-duration" in response.
+	ATTR integer notify-lease-duration 1000
+
+	STATUS successful-ok
+
+	EXPECT notify-lease-duration WITH-VALUE >0
+}
+
+{
+	# testing cancel-subscription operation
+
+	NAME "cancel-subscription"
+	OPERATION "Cancel-Subscription"
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-subscription-id $renew-cancel-id
+	ATTR name requesting-user-name $user
+
+	STATUS successful-ok
+}
+
+{
+    # checking whether the subscription has been canceled
+
+    NAME "get-notifications"
+	OPERATION Get-Notifications
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-subscription-ids $renew-cancel-id
+	ATTR name requesting-user-name $user
+
+	STATUS client-error-not-found
+}
+
+{
+	# checking the create-job-subscription-operation
+
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB_SUBSCRIPTION
+
+	NAME "print-job"
+	OPERATION Print-Job
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR name requesting-user-name $user
+	ATTR mimeMediaType document-format $filetype
+
+	GROUP job-attributes-tag
+	ATTR integer copies 1
+
+	FILE $filename
+
+	STATUS successful-ok
+
+	EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag WITH-VALUE >0 COUNT 1
+}
+
+{
+	# checking the create-job-subscription-operation
+
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB_SUBSCRIPTION
+
+	NAME "Create per-job subscription"
+	OPERATION create-job-subscription
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR integer notify-job-id $job-id
+	ATTR name requesting-user-name $user
+	
+	GROUP subscription-attributes-tag
+	ATTR keyword notify-pull-method ippget
+	ATTR keyword notify-events job-state-changed
+
+	STATUS successful-ok
+
+	EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+}
+
+{
+    # get subscription attributes and check for REQUIRED attributes
+
+	SKIP-IF-NOT-DEFINED HAVE_CREATE_JOB_SUBSCRIPTION
+
+    NAME "Get subscription attributes"
+    OPERATION Get-subscription-attributes
+
+    GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+    ATTR integer notify-subscription-id $notify-subscription-id
+    ATTR name requesting-user-name $user
+    ATTR keyword requested-attributes all
+
+    STATUS successful-ok
+
+    EXPECT notify-pull-method OF-TYPE keyword IN-GROUP subscription-attributes-tag WITH-VALUE "ippget" COUNT 1
+	EXPECT notify-events OF-TYPE keyword IN-GROUP subscription-attributes-tag WITH-VALUE "job-state-changed"
+    
+	EXPECT notify-charset OF-TYPE charset IN-GROUP subscription-attributes-tag WITH-VALUE "utf-8" COUNT 1      		
+	EXPECT notify-natural-language OF-TYPE naturalLanguage IN-GROUP subscription-attributes-tag WITH-VALUE "en" COUNT 1	
+
+#ISSUE: notify-lease-duration isn't defined for a per-job-subscription object, but it shows up here.
+    EXPECT !notify-lease-duration
+
+	EXPECT !notify-time-interval
+    EXPECT notify-subscription-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >0 COUNT 1
+    EXPECT notify-sequence-number OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE >-1 COUNT 1
+
+#ISSUE: notify-lease-expiration-time and notify-printer-up-time must not show up for per-job subscription object.
+    EXPECT !notify-lease-expiration-time 
+    EXPECT !notify-printer-up-time
+    
+	EXPECT notify-printer-uri OF-TYPE uri IN-GROUP subscription-attributes-tag COUNT 1
+
+#ISSUE: notify-job-id must be returned for per-job-subscription object.
+	EXPECT notify-job-id OF-TYPE integer IN-GROUP subscription-attributes-tag WITH-VALUE $job-id COUNT 1
+    
+	EXPECT notify-subscriber-user-name OF-TYPE name IN-GROUP subscription-attributes-tag WITH-VALUE $user COUNT 1	
+	EXPECT !notify-status-code	
+}


### PR DESCRIPTION
Add testfiles that are based on different IPP components, so that printer-manufacturers can check whether the printer satisfies particular IPP standards. (Part of work under Google Summer of Code 2018).