### PR TITLE
Free band buffer after use

### DIFF
--- a/tools/ipptransform.c
+++ b/tools/ipptransform.c
@@ -2083,6 +2083,9 @@ xform_document(
 
   CGContextRelease(context);
 
+  free(ras.band_buffer);
+  ras.band_buffer = NULL;
+
   return (0);
 }
 


### PR DESCRIPTION
I have analyzed memory allocation and leaks of ipptransform.c, we currently use `xform_document` from a Swift context and noticed that the `bandBuffer` was leaking.

It's a simple fix and tested many times over.