### PR TITLE
Free type_array after use

### DIFF
--- a/tools/ipptransform.c
+++ b/tools/ipptransform.c
@@ -2918,6 +2918,8 @@ xform_setup(xform_raster_t *ras,	/* I - Raster information */
       type = "cmyk_8";
   }
 
+  cupsArrayDelete(type_array);
+
   if (!type)
   {
     fputs("ERROR: No supported raster types are available.\n", stderr);


### PR DESCRIPTION
I have analyzed memory allocation and leaks of ipptransform.c, we currently use `xform_document` from a Swift context and noticed that the `type_array` was leaking.

This fix has also been tested many times over.

## Off-topic
After @michaelrsweet warned be about possibly huge memory consumption I rasterized a few different documents. Biggest memory consumption was about 20MB with the [Apollo 17 Flight Plan](https://www.hq.nasa.gov/alsj/a17/A17_FlightPlan.pdf). All-in-all it works very reliably, and with two minor fixes also without leaking memory.
