### PR TITLE
Fixing tzdata interactive config to non-interactive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qq update && apt-get install -y build-essential autoconf avahi-daemon avahi-utils cura-engine libavahi-client-dev libfreetype6-dev libgnutls28-dev libharfbuzz-dev libjbig2dec0-dev libjpeg-dev libmupdf-dev libnss-mdns libopenjp2-7-dev libpng-dev zlib1g-dev net-tools iputils-ping vim avahi-daemon tcpdump man curl
 RUN /bin/echo 'colorscheme blue' > ~/.vimrc
 RUN /bin/echo "LS_COLORS=\$LS_COLORS:'di=0;31:' ; export LS_COLORS" >> /root/.bashrc


### PR DESCRIPTION
I was trying to bring up the ippsample as part of my ramp up for LFMP-Scan project and I came across an issue. During the docker build we get an interactive mode for configuring tzdata as follows:
```
Setting up libgomp1:amd64 (10-20200411-0ubuntu1) ...
Setting up libffi-dev:amd64 (3.3-4) ...
Setting up libldap-common (2.4.49+dfsg-2ubuntu1.3) ...
Setting up libpcre2-16-0:amd64 (10.34-7) ...
Setting up xxd (2:8.1.2269-1ubuntu5) ...
Setting up libcap2:amd64 (1:2.32-1) ...
Setting up libfakeroot:amd64 (1.24-1) ...
Setting up libkrb5support0:amd64 (1.17-6ubuntu4) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg-2) ...
Setting up tzdata (2020a-0ubuntu0.20.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:
```
Even after giving the zone details docker build hangs. So I added a fix making it non-interactive. After which I was able to build the docker image and I was able to do the examples from your tutorials.

@michaelrsweet  Can you please give me a feedback?