### PR TITLE
Make cupsDirRead on Windows act more like POSIX

### DIFF
--- a/cups/dir.c
+++ b/cups/dir.c
@@ -123,6 +123,8 @@ cupsDirOpen(const char *directory)	/* I - Directory name */
   dp->dir = INVALID_HANDLE_VALUE;
 
   strlcpy(dp->directory, directory, sizeof(dp->directory));
+  if (strlcat(dp->directory, "\\*", sizeof(dp->directory)) >= sizeof(dp->directory)) /* FindFirstFile needs a pattern */
+    return (NULL);
 
  /*
   * Return the new directory structure...


### PR DESCRIPTION
FindFirstFile needs a pattern suffix added to the path.
Here's an [example](https://docs.microsoft.com/en-us/windows/win32/fileio/listing-the-files-in-a-directory).

This one small fix improves #228 such that the config files are loaded, but something else is not quite right:

> 2021-05-25T13:02:25.559Z  Using default data directory "C:\\Users\\nick\\AppData\\Local\\Temp/ippserver.37636".
> 2021-05-25T13:02:25.560Z  Using default spool directory "C:\\Users\\nick\\AppData\\Local\\Temp/ippserver.37636".
> 2021-05-25T13:02:25.593Z  Using default listeners for localhost:8631.
> 2021-05-25T13:02:25.594Z  Loading printers from "test/system.conf".
> 2021-05-25T13:02:25.595Z  Skipping ".".
> 2021-05-25T13:02:25.596Z  Skipping "..".
> 2021-05-25T13:02:25.596Z  Loading printer from "foo.conf".
> 2021-05-25T13:02:25.602Z  [Printer foo] printer-uri="ipp://localhost:8631/ipp/print/foo"
> 2021-05-25T13:02:25.645Z  Loading printer from "infra.conf".
> 2021-05-25T13:02:25.645Z  Unknown directive "AuthProxyGroup" on line 2 of "test/print/infra.conf".
> 2021-05-25T13:02:25.645Z  [Printer infra] printer-uri="ipp://localhost:8631/ipp/print/infra"
> 2021-05-25T13:02:25.655Z  Loading printer from "ipp-everywhere-pdf.conf".
> 2021-05-25T13:02:25.658Z  [Printer ipp-everywhere-pdf] printer-uri="ipp://localhost:8631/ipp/print/ipp-everywhere-pdf"
> 2021-05-25T13:02:25.669Z  Loading printer from "ipp-everywhere-raster.conf".
> 2021-05-25T13:02:25.672Z  [Printer ipp-everywhere-raster] printer-uri="ipp://localhost:8631/ipp/print/ipp-everywhere-raster"
> 2021-05-25T13:02:25.683Z  Loading printer from "ippserver-data-type-test.conf".
> 2021-05-25T13:02:25.686Z  [Printer ippserver-data-type-test] printer-uri="ipp://localhost:8631/ipp/print/ippserver-data-type-test"
> 2021-05-25T13:02:25.698Z  Loading 3D printers from "test/print/ippserver-data-type-test.conf".
> 2021-05-25T13:02:25.699Z  Skipping ".".
> 2021-05-25T13:02:25.699Z  Skipping "..".
> 2021-05-25T13:02:25.699Z  Loading 3D printer from "foo3d.conf".
> 2021-05-25T13:02:25.702Z  [Printer foo3d] printer-uri="ipp://localhost:8631/ipp/print3d/foo3d"
> 2021-05-25T13:02:26.620Z  [Printer ippserver-data-type-test] Now using DNS-SD service name "ippserver-data-type-test (2)".