### PR TITLE
Improve docker image autobuild workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   workflow_run:
     workflows: [ "Build and Test" ]
+    branches: [ master ]
     types: [ completed ]
   push:
     branches-ignore: [ master ]


### PR DESCRIPTION
Improves #239, #240

Adds the option to push image to Github container registry and/or docker hub

Uses the following secrets:
- GHCR_IMAGE
- GITHUB_TOKEN
- DOCKERHUB_IMAGE
- DOCKERHUB_TOKEN
- DOCKERHUB_USERNAME

Currently tags images by sha.  A follow up commit can add semver tags or something more user friendly

Simple sanity check runs most commands (see #244) expected to be available.  A follow up commit can test they work as expected.