### PR TITLE
Improve docker image autobuild workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,6 @@ jobs:
       IMAGE_TAG: ${{ steps.setter.outputs.IMAGE_TAG }}
     steps:
       - id: setter
-        shell: bash
         run: |
           BRANCH_NAME=${GITHUB_HEAD_REF-}
           if [ "$BRANCH_NAME" == "" ]; then


### PR DESCRIPTION
Supersedes #242 

Improves #239, #240

Adds the option to push image to Github container registry and/or docker hub

Uses the following secrets:
- GHCR_IMAGE
- GITHUB_TOKEN
- DOCKERHUB_IMAGE
- DOCKERHUB_TOKEN
- DOCKERHUB_USERNAME

Simple sanity check runs most commands (see #244) expected to be available.  A follow up commit can test they work as expected.

Currently, the docker image is built and tested for the master branch after the test workflow completes.  It is built on every commit for PRs to provide continuous feedback during development.

The image is explicitly tagged with the branch/tag, sha, and timestamp.  Not sure how you will want release tags to work, but the template is laid out. The `workflow_run` trigger is used to ensure we only push images that have completed the "Build and Test" job on the master branch with a successful conclusion per `github.event.workflow_run.conclusion == 'success'`. It would be simple to add `:stable` or something along those lines when pushing the image - this should be straightforward to adjust in a follow up commit. 

Images are saved as artifacts with a unique name based on these details to shuffle between steps.  This keeps development images from getting into the docker repo and lingering around.  Currently, we rely on the artifact retention of 1 day to remove old artifacts after jobs complete.  There is supposedly an API for removing them but it is unclear if this can work within the running workflow (refer to https://github.com/actions/upload-artifact/issues/5)
